### PR TITLE
[th/more-pxeboot] more features to pxeboot and various minor changes

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,6 +21,8 @@ jobs:
         python -m pip install black
         python -m pip install flake8
         python -m pip install mypy
+        python -m pip install pytest
+        python -m pip install types-PyYAML
         python -m pip install -r requirements.txt
     - name: Check code formatting with Black
       run: |
@@ -34,3 +36,7 @@ jobs:
       run: |
        mypy --version
        mypy --strict --config-file mypy.ini .
+    - name: Run tests with Pytest
+      run: |
+       pytest --version
+       pytest -vv .

--- a/Containerfile
+++ b/Containerfile
@@ -11,6 +11,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         iproute \
         iputils \
         minicom \
+        nftables \
         procps \
         python-unversioned-command \
         python3-pexpect \

--- a/Containerfile
+++ b/Containerfile
@@ -14,8 +14,8 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         nftables \
         procps \
         python-unversioned-command \
-        python3-pexpect \
         python3-pip \
+        python3-pyserial \
         python3-pyyaml \
         python3-requests \
         python3-types-pyyaml \

--- a/Containerfile
+++ b/Containerfile
@@ -5,6 +5,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf install -y epel-next-release epel-release && \
     dnf upgrade -y --skip-broken --allowerasing && \
     dnf install \
+        /usr/bin/ssh-keygen \
         dhcp-server \
         ethtool \
         iproute \

--- a/Containerfile
+++ b/Containerfile
@@ -28,5 +28,6 @@ COPY ./manifests /marvell-octeon-10-tools/manifests
 
 COPY manifests/.minirc.dfl /root/
 
+WORKDIR /marvell-octeon-10-tools
 ENTRYPOINT ["/usr/bin/tini", "-s", "-p", "SIGTERM", "-g", "-e", "143", "--"]
 CMD ["/usr/bin/sleep", "infinity"]

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,9 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         python-unversioned-command \
         python3-pexpect \
         python3-pip \
+        python3-pyyaml \
         python3-requests \
+        python3-types-pyyaml \
         python39 \
         tftp \
         tftp-server \
@@ -23,7 +25,8 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         -y && \
     echo "export PYTHONPATH=/marvell-octeon-10-tools" > /etc/profile.d/marvell-octeon-10-tools.sh
 
-COPY ./*.py ./*sh /marvell-octeon-10-tools/
+COPY ./*.py ./*sh ./mypy.ini /marvell-octeon-10-tools/
+COPY ktoolbox/README.md ktoolbox/*.py /marvell-octeon-10-tools/ktoolbox/
 COPY ./manifests /marvell-octeon-10-tools/manifests
 
 COPY manifests/.minirc.dfl /root/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ sudo podman run --pull always --rm --replace --privileged --pid host --network h
 
 Utilize the serial interface at /dev/ttyUSB0 to pxeboot the card with the provided ISO
 
+The tool makes several assumptions.
+
+- The tool is for installing RHEL from an ISO via PXE. An HTTP url can be specified instead
+  of an URL, in that case, it is downloaded to "/host/root/rhel-iso-*". You can also set
+  "rhel:9.x" to use the latest RHEL 9.x nightly image.
+
+- The DPU's serial interface is on /dev/ttyUSB0.
+
+- The DPU's management interface (enP2p3s0) is connected back to the host (usually on "eno4", see "--dev" argument).
+  On the DPU, a NetworkManager profile "enP2p3s0-dpu-host" will be created with static IP address 172.131.100.100/24
+  (DHCP and SLAAC are enabled too).
+  On the host, "eno4" should have address 172.131.100.1/24 and setup NAT for forwarding traffic. The tool
+  takes care of that, see `nft list table ip marvell-tools-nat-eno4`.
+
+- The DPU's secondary interface (enP2p2s0) is connected to the provisioning host, where we expect to run DHCP.
+  On the DPU, a NetworkManager profile "enP2p3s0-dpu-secondary" will be created with DHCP and SLAAC enabled.
+  If a DHCP server is running on the other end, it should also setup NAT to connect the DPU to the internet.
+
+- Profile enP2p3s0-dpu-secondary has a better route metric than enP2p3s0-dpu-host and will be preferred to
+  reach the internet. Both profiles attempt DHCP/SLAAC indefinitely.
+
+- The host is expected to run RHEL or CoreOS. See also options "--host-setup-only" and "--host-mode".
+  On the host:
+
+  - It configures a NetworkManager connection profile "eno4-marvell-dpu" for "eno4" and activates it.
+    This configuration is persisted.
+
+  - Configures nftables (`nft list table ip marvell-tools-nat-eno4`) and "net.ipv4.ip_forward". This
+    configuration is ephemeral. It can be redone after reboot with "--host-setup-only".
+
+
 Usage:
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ Marvell Octeon 10 Tools
 
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest
-sudo podman run --pull always --replace --pid host --network host --user 0 --name marvell-tools -dit --privileged -v /dev:/dev "$IMAGE"
-sudo podman exec -it marvell-tools <cmd>
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" <cmd>
 ```
 
 ## Tools
@@ -15,7 +14,9 @@ Utilize the serial interface at /dev/ttyUSB1 to trigger a reset of the associate
 
 Usage:
 ```
-python /marvell-octeon-10-tools/reset.py
+IMAGE=quay.io/sdaniele/marvell-tools:latest
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
+  ./reset.py
 ```
 
 ### PxeBoot
@@ -25,8 +26,8 @@ Utilize the serial interface at /dev/ttyUSB0 to pxeboot the card with the provid
 Usage:
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest
-sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -dit "$IMAGE"
-sudo podman exec -it marvell-tools python /marvell-octeon-10-tools/pxeboot.py --dev eno4 /host/root/RHEL-9.4.0-20240312.96-aarch64-dvd1.iso
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
+  ./pxeboot.py --dev eno4 /host/root/RHEL-9.4.0-20240312.96-aarch64-dvd1.iso
 ```
 
 ### FW Updater
@@ -36,9 +37,8 @@ Utilize the serial interface at /dev/ttyUSB0 to update the card with the provide
 Usage:
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest
-sudo podman run --pull always --replace --pid host --network host --user 0 --name marvell-tools -dit --privileged -v /dev:/dev -v /root/flash-uefi-cn10ka-11.24.02.img:/tmp/img "$IMAGE"
-sudo podman exec -it marvell-tools /bin/bash
-python /marvell-octeon-10-tools/fwupdate.py --dev eno4 /tmp/img
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
+  ./fwupdate.py --dev eno4 /host/root/flash-uefi-cn10ka-11.24.02.img
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage:
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest
 sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
-  ./pxeboot.py --dev eno4 /host/root/RHEL-9.4.0-20240312.96-aarch64-dvd1.iso
+  ./pxeboot.py --help
 ```
 
 ### FW Updater

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -1,11 +1,13 @@
+import dataclasses
+import logging
 import os
 import shlex
 import subprocess
-import dataclasses
 
 from typing import Optional
 
 from ktoolbox import host
+from ktoolbox.logger import logger
 
 
 dpu_ip4addr = "172.131.100.100"
@@ -103,3 +105,48 @@ def ssh_read_pubkey(ssh_privkey_file: str) -> str:
         if s:
             return s
     raise RuntimeError('failure to read SSH public key from "{ssh_pubkey_file}"')
+
+
+def create_iso_file(iso: str, chroot_path: str) -> str:
+
+    iso0 = iso
+
+    if iso0.startswith("rhel:"):
+        rhel_version = iso0[len("rhel:") :]
+        if rhel_version == "":
+            # This is the default.
+            rhel_version = "9.4"
+        url = f"https://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-{rhel_version}.0/compose/BaseOS/aarch64/iso/"
+        res = host.local.run(
+            f'curl -k -s {shlex.quote(url)} | sed -n \'s/.*href="\\(RHEL-[^"]\\+-dvd1.iso\\)".*/\\1/p\' | head -n1',
+            log_level_fail=logging.ERROR,
+        )
+        url_part = res.out.strip()
+        if not res.success or not url_part:
+            raise RuntimeError(
+                f'failure to detect URL for RHEL ISO image "{iso0}" at URL "{url}"'
+            )
+        iso1 = f"{url}{url_part}"
+    else:
+        iso1 = iso0
+
+    if iso1.startswith("http://") or iso1.startswith("https://"):
+        filename = iso1[(iso1.rfind("/") + 1) :]
+        iso2 = os.path.join(chroot_path, f"root/rhel-iso-{filename}")
+        if not os.path.exists(iso2):
+            ret = host.local.run(
+                f"curl -k -o {shlex.quote(iso2)} {shlex.quote(iso1)}",
+                log_level_fail=logging.ERROR,
+            )
+            if not ret.success:
+                raise RuntimeError(
+                    f'failure to download RHEL ISO image "{iso1}" to "{iso2}"'
+                )
+    else:
+        iso2 = iso1
+
+    if not os.path.exists(iso2):
+        raise RuntimeError(f'iso path "{iso}" ("{iso2}") does not exist')
+
+    logger.info(f"use iso {shlex.quote(iso2)}")
+    return iso2

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -6,10 +6,12 @@ import subprocess
 
 from typing import Optional
 
+from ktoolbox import firewall
 from ktoolbox import host
 from ktoolbox.logger import logger
 
 
+dpu_subnet = "172.131.100.0/24"
 dpu_ip4addr = "172.131.100.100"
 dpu_ip4addrnet = f"{dpu_ip4addr}/24"
 host_ip4addr = "172.131.100.1"
@@ -80,6 +82,16 @@ def nmcli_setup_mngtiface(
             die_on_error=True,
         )
     host.local.run(f"{chroot_prefix}nmcli connection up {con_spec}", die_on_error=True)
+
+
+def nft_masquerade(ifname: str, subnet: str) -> None:
+    firewall.nft_call(
+        firewall.nft_data_masquerade_up(
+            table_name=f"marvell-tools-nat-{ifname}",
+            ifname=ifname,
+            subnet=subnet,
+        )
+    )
 
 
 def ssh_generate_key(chroot_path: str) -> str:

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -3,6 +3,16 @@ import shlex
 import subprocess
 import dataclasses
 
+from typing import Optional
+
+from ktoolbox import host
+
+
+dpu_ip4addr = "172.131.100.100"
+dpu_ip4addrnet = f"{dpu_ip4addr}/24"
+host_ip4addr = "172.131.100.1"
+host_ip4addrnet = f"{host_ip4addr}/24"
+
 
 def minicom_cmd(device: str) -> str:
     return f"minicom -D {device}"
@@ -36,3 +46,35 @@ def run(cmd: str, env: dict[str, str] = os.environ.copy()) -> Result:
 
 def packaged_file(relative_path: str) -> str:
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), relative_path)
+
+
+def nmcli_setup_mngtiface(
+    ifname: str,
+    chroot_path: Optional[str],
+    ip4addr: str,
+) -> None:
+    """
+    Setup the management interface with a static IP address. For that, ensure we have
+    such a connection profile f"{ifname}-marvell-dpu" in NetworkManager. Configure static IP addresses.
+    """
+    chroot_prefix = ""
+    if chroot_path is not None:
+        chroot_prefix = f"chroot {shlex.quote(chroot_path)} "
+    con_name = f"{ifname}-marvell-dpu"
+    res = host.local.run(
+        f"{chroot_prefix}nmcli -g connection.uuid connection show id {shlex.quote(con_name)}"
+    )
+    if not res.success:
+        host.local.run(
+            f"{chroot_prefix}nmcli connection add type ethernet con-name {shlex.quote(con_name)} ifname {shlex.quote(ifname)} ipv4.method manual ipv4.addresses {shlex.quote(ip4addr)} ipv6.method link-local ipv6.addr-gen-mode eui64",
+            die_on_error=True,
+        )
+        con_spec = f"id {shlex.quote(con_name)}"
+    else:
+        uuid = res.out.split()[0]
+        con_spec = f"uuid {shlex.quote(uuid)}"
+        host.local.run(
+            f"{chroot_prefix}nmcli connection modify {con_spec} con-name {shlex.quote(con_name)} ifname {shlex.quote(ifname)} ipv4.method manual ipv4.addresses {shlex.quote(ip4addr)} ipv6.method link-local ipv6.addr-gen-mode eui64",
+            die_on_error=True,
+        )
+    host.local.run(f"{chroot_prefix}nmcli connection up {con_spec}", die_on_error=True)

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -21,10 +21,10 @@ host_ip4addrnet = f"{host_ip4addr}/24"
 ESC = "\x1b"
 KEY_DOWN = "\x1b[B"
 KEY_ENTER = "\r\n"
+KEY_CTRL_M = "\r"
 
-
-def minicom_cmd(device: str) -> str:
-    return f"minicom -D {device}"
+TTYUSB0 = "/dev/ttyUSB0"
+TTYUSB1 = "/dev/ttyUSB1"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -105,9 +105,11 @@ def nft_masquerade(ifname: str, subnet: str) -> None:
     )
 
 
-def ssh_generate_key(chroot_path: str) -> str:
+def ssh_generate_key(chroot_path: str, *, create: bool = True) -> Optional[str]:
     file = f"{chroot_path}/root/.ssh/id_ed25519"
     if not os.path.exists(file) or not os.path.exists(f"{file}.pub"):
+        if not create:
+            return None
         try:
             os.mkdir(os.path.dirname(file))
         except FileExistsError:

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -18,6 +18,10 @@ dpu_ip4addrnet = f"{dpu_ip4addr}/24"
 host_ip4addr = "172.131.100.1"
 host_ip4addrnet = f"{host_ip4addr}/24"
 
+ESC = "\x1b"
+KEY_DOWN = "\x1b[B"
+KEY_ENTER = "\r\n"
+
 
 def minicom_cmd(device: str) -> str:
     return f"minicom -D {device}"

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -78,3 +78,28 @@ def nmcli_setup_mngtiface(
             die_on_error=True,
         )
     host.local.run(f"{chroot_prefix}nmcli connection up {con_spec}", die_on_error=True)
+
+
+def ssh_generate_key(chroot_path: str) -> str:
+    file = f"{chroot_path}/root/.ssh/id_ed25519"
+    if not os.path.exists(file) or not os.path.exists(f"{file}.pub"):
+        try:
+            os.mkdir(os.path.dirname(file))
+        except FileExistsError:
+            pass
+        host.local.run(
+            f'ssh-keygen -t ed25519 -C marvell-tools@local.local -N "" -f {shlex.quote(file)}',
+            die_on_error=True,
+        )
+    return file
+
+
+def ssh_read_pubkey(ssh_privkey_file: str) -> str:
+    ssh_pubkey_file = f"{ssh_privkey_file}.pub"
+    with open(ssh_pubkey_file, "r") as f:
+        ssh_pubkey = f.read()
+    for s in ssh_pubkey.splitlines():
+        s = s.strip()
+        if s:
+            return s
+    raise RuntimeError('failure to read SSH public key from "{ssh_pubkey_file}"')

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import subprocess
 
+from multiprocessing import Process
 from typing import Optional
 
 from ktoolbox import firewall
@@ -46,6 +47,12 @@ def run(cmd: str, env: dict[str, str] = os.environ.copy()) -> Result:
 
     print(f"Result: {result.out}\n{result.err}\n{result.returncode}\n")
     return result
+
+
+def run_process(cmd: str) -> Process:
+    p = Process(target=run, args=(cmd,))
+    p.start()
+    return p
 
 
 def packaged_file(relative_path: str) -> str:

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -4,7 +4,6 @@ import argparse
 import os
 import pexpect
 import shutil
-import signal
 import time
 
 from collections.abc import Iterable
@@ -182,26 +181,8 @@ def try_fwupdate(args: argparse.Namespace) -> None:
         e.terminate()
 
 
-def kill_existing() -> None:
-    pids = [pid for pid in os.listdir("/proc") if pid.isdigit()]
-
-    own_pid = os.getpid()
-    for pid in filter(lambda x: int(x) != own_pid, pids):
-        try:
-            with open(os.path.join("/proc", pid, "cmdline"), "rb") as f:
-                # print(f.read().decode("utf-8"))
-                zb = b"\x00"
-                cmd = [x.decode("utf-8") for x in f.read().strip(zb).split(zb)]
-                if "python" in cmd[0] and os.path.basename(cmd[1]) == "fwupdate.py":
-                    print(f"Killing pid {pid}")
-                    os.kill(int(pid), signal.SIGKILL)
-        except Exception:
-            pass
-
-
 def main() -> None:
     args = parse_args()
-    kill_existing()
     try_fwupdate(args)
 
 

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -11,6 +11,8 @@ from multiprocessing import Process
 
 import common_dpu
 
+from common_dpu import ESC
+from common_dpu import KEY_ENTER
 from common_dpu import minicom_cmd
 from common_dpu import run
 from reset import reset
@@ -64,11 +66,6 @@ def wait_any_ping(hn: Iterable[str], timeout: float) -> str:
 def ping(hn: str) -> bool:
     ping_cmd = f"timeout 1 ping -4 -c 1 {hn}"
     return run(ping_cmd).returncode == 0
-
-
-ESC = "\x1b"
-KEY_DOWN = "\x1b[B"
-KEY_ENTER = "\r\n"
 
 
 def firmware_update(img_path: str) -> None:

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import os
 import pexpect

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -134,13 +134,6 @@ def firmware_update(img_path: str) -> None:
     print("Closing minicom")
 
 
-def uboot_firmware_update(args: argparse.Namespace) -> None:
-    print("Starting FW Update")
-    print("Resetting card")
-    reset()
-    firmware_update(args.img)
-
-
 def setup_tftp(img: str) -> None:
     print("Configuring TFTP")
     os.makedirs("/var/lib/tftpboot", exist_ok=True)
@@ -165,25 +158,20 @@ def setup_dhcp(dev: str) -> None:
     children.append(p)
 
 
-def prepare_fwupdate(args: argparse.Namespace) -> None:
+def main() -> None:
+    args = parse_args()
+    print("Preparing services for FW update")
     setup_dhcp(args.dev)
     setup_tftp(args.img)
-
-
-def try_fwupdate(args: argparse.Namespace) -> None:
-    print("Preparing services for FW update")
-    prepare_fwupdate(args)
     print("Giving services time to settle")
     time.sleep(10)
-    uboot_firmware_update(args)
+    print("Starting FW Update")
+    print("Resetting card")
+    reset()
+    firmware_update(args.img)
     print("Terminating http, tftp, and dhcpd")
     for e in children:
         e.terminate()
-
-
-def main() -> None:
-    args = parse_args()
-    try_fwupdate(args)
 
 
 if __name__ == "__main__":

--- a/ktoolbox/README.md
+++ b/ktoolbox/README.md
@@ -1,0 +1,11 @@
+ktoolbox
+=======
+
+Then `ktoolbox` package contains some basic utilities. It's (current) primary location is
+ocp-traffic-flow-tests ([1]), but it can be reused by just copying the entire directory.
+
+[1] https://github.com/wizhaoredhat/ocp-traffic-flow-tests/tree/main/ktoolbox
+
+If you copy/fork the directory, make sure to not modify the fork. Instead,
+extend the primary location first, and then reimport all files. This is to
+avoid diverging implementations. It requires self-constraint.

--- a/ktoolbox/common.py
+++ b/ktoolbox/common.py
@@ -1,0 +1,787 @@
+import abc
+import dataclasses
+import functools
+import json
+import os
+import re
+import time
+import typing
+
+from collections.abc import Iterable
+from collections.abc import Mapping
+from dataclasses import dataclass
+from dataclasses import fields
+from dataclasses import is_dataclass
+from enum import Enum
+from typing import Any
+from typing import Optional
+from typing import Type
+from typing import TypeVar
+from typing import Union
+from typing import cast
+
+if typing.TYPE_CHECKING:
+    # https://github.com/python/typeshed/tree/main/stdlib/_typeshed#api-stability
+    # https://github.com/python/typeshed/blob/6220c20d9360b12e2287511587825217eec3e5b5/stdlib/_typeshed/__init__.pyi#L349
+    from _typeshed import DataclassInstance
+    from types import TracebackType
+
+
+PathType = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
+
+E = TypeVar("E", bound=Enum)
+T = TypeVar("T")
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+TCallable = typing.TypeVar("TCallable", bound=typing.Callable[..., typing.Any])
+
+
+# This is used as default value for some arguments, to recognize that the
+# caller didn't specify the argument. This is useful, when we want to
+# explicitly distinguish between having an argument unset or set to any value.
+# The caller would never pass this value, but the implementation would check
+# whether the argument is still left at the default.
+#
+# See also, dataclasses.MISSING and dataclasses._MISSING_TYPE
+class _MISSING_TYPE:
+    pass
+
+
+MISSING = _MISSING_TYPE()
+
+# kw_only is Python3.10+. This annotation is very useful, so make it available
+# with 3.9 without breaking mypy.
+#
+# This silences up mypy while retaining the error checking at runtime. It however
+# looses the ability for mypy to detect the error at lint time.
+#
+# So, using this acts as a comment to the reader that the code expects kw_only.
+# It is also enforced at runtime. It also allows to find all the places where
+# we would like to use kw_only=True but cannot due to Python 3.9 compatibility.
+KW_ONLY_DATACLASS = {"kw_only": True} if "kw_only" in dataclass.__kwdefaults__ else {}
+
+
+def bool_to_str(val: bool, *, format: str = "true") -> str:
+    if format == "true":
+        return "true" if val else "false"
+    if format == "yes":
+        return "yes" if val else "no"
+    raise ValueError(f'Invalid format "{format}"')
+
+
+def str_to_bool(
+    val: Optional[Union[str, bool]],
+    on_error: Union[T1, _MISSING_TYPE] = MISSING,
+    *,
+    on_default: Union[T2, _MISSING_TYPE] = MISSING,
+) -> Union[bool, T1, T2]:
+
+    is_default = False
+
+    if isinstance(val, str):
+        val2 = val.lower().strip()
+        if val2 in ("1", "y", "yes", "true", "on"):
+            return True
+        if val2 in ("0", "n", "no", "false", "off"):
+            return False
+        if val2 in ("", "default", "-1"):
+            is_default = True
+    elif val is None:
+        # None is (maybe) accepted as default value.
+        is_default = True
+    elif isinstance(val, bool):
+        # For convenience, also accept that the value is already a boolean.
+        return val
+
+    if is_default and not isinstance(on_default, _MISSING_TYPE):
+        # The value is explicitly set to one of the recognized default values
+        # (None, "default", "-1" or "").
+        #
+        # By setting @on_default, the caller can use str_to_bool() to not only
+        # parse boolean values, but ternary values.
+        return on_default
+
+    if not isinstance(on_error, _MISSING_TYPE):
+        # On failure, we return the fallback value.
+        return on_error
+
+    raise ValueError(f"Value {val} is not a boolean")
+
+
+def iter_get_first(
+    lst: Iterable[T],
+    *,
+    unique: bool = False,
+    force_unique: bool = False,
+) -> Optional[T]:
+    v0: Optional[T] = None
+    for idx, v in enumerate(lst):
+        if idx == 0:
+            v0 = v
+            continue
+        if force_unique:
+            raise RuntimeError("Iterable was expected to only contain one entry")
+        if unique:
+            # We have more than one entries. The caller requested to reject
+            # that.
+            return None
+        return v0
+    return v0
+
+
+def iter_filter_none(lst: Iterable[Optional[T]]) -> Iterable[T]:
+    for v in lst:
+        if v is not None:
+            yield v
+
+
+def enum_convert(
+    enum_type: Type[E],
+    value: Any,
+    default: Optional[E] = None,
+) -> E:
+
+    if value is None:
+        # We only allow None, if the caller also specified a default value.
+        if default is not None:
+            return default
+    elif isinstance(value, enum_type):
+        return value
+    elif isinstance(value, int):
+        try:
+            return enum_type(value)
+        except ValueError:
+            raise ValueError(f"Cannot convert {value} to {enum_type}")
+    elif isinstance(value, str):
+        v = value.strip()
+
+        # Try lookup by name.
+        try:
+            return enum_type[v]
+        except KeyError:
+            pass
+
+        # Try the string as integer value.
+        try:
+            return enum_type(int(v))
+        except Exception:
+            pass
+
+        # Finally, try again with all upper case. Also, all "-" are replaced
+        # with "_", but only if the result is unique.
+        v2 = v.upper().replace("-", "_")
+        matches = [e for e in enum_type if e.name.upper() == v2]
+        if len(matches) == 1:
+            return matches[0]
+
+        raise ValueError(f"Cannot convert {value} to {enum_type}")
+
+    raise ValueError(f"Invalid type for conversion to {enum_type}")
+
+
+def enum_convert_list(enum_type: Type[E], value: Any) -> list[E]:
+    output: list[E] = []
+
+    if isinstance(value, str):
+        for part in value.split(","):
+            part = part.strip()
+            if not part:
+                # Empty words are silently skipped.
+                continue
+
+            cases: Optional[list[E]] = None
+
+            # Try to parse as a single enum value.
+            try:
+                cases = [enum_convert(enum_type, part)]
+            except Exception:
+                cases = None
+
+            if part == "*":
+                # Shorthand for the entire range (sorted by numeric values)
+                cases = sorted(enum_type, key=lambda e: e.value)
+
+            if cases is None:
+                # Could not be parsed as single entry. Try to parse as range.
+
+                def _range_endpoint(s: str) -> int:
+                    try:
+                        return int(s)
+                    except Exception:
+                        pass
+                    return cast(int, enum_convert(enum_type, s).value)
+
+                try:
+                    # Try to detect this as range. Both end points may either by
+                    # an integer or an enum name.
+                    #
+                    # Note that since we use "-" to denote the range, we cannot have
+                    # a range that involves negative enum values (otherwise, enum_convert()
+                    # is fine to parse a single enum from a negative number in a string).
+                    start, end = [_range_endpoint(s) for s in part.split("-")]
+                except Exception:
+                    # Couldn't parse as range.
+                    pass
+                else:
+                    # We have a range.
+                    cases = None
+                    for i in range(start, end + 1):
+                        try:
+                            e = enum_convert(enum_type, i)
+                        except Exception:
+                            # When specifying a range, then missing enum values are
+                            # silently ignored. Note that as a whole, the range may
+                            # still not be empty.
+                            continue
+                        if cases is None:
+                            cases = []
+                        cases.append(e)
+
+            if cases is None:
+                raise ValueError(f"Invalid test case id: {part}")
+
+            output.extend(cases)
+    elif isinstance(value, list):
+        for idx, part in enumerate(value):
+            # First, try to parse the list entry with plain enum_convert.
+            cases = None
+            try:
+                cases = [enum_convert(enum_type, part)]
+            except Exception:
+                # Now, try to parse as a list (but only if we have a string, no lists in lists).
+                if isinstance(part, str):
+                    try:
+                        cases = enum_convert_list(enum_type, part)
+                    except Exception:
+                        pass
+            if not cases:
+                raise ValueError(
+                    f'list at index {idx} contains invalid value "{part}" for enum {enum_type}'
+                )
+            output.extend(cases)
+    else:
+        raise ValueError(f"Invalid {enum_type} value of type {type(value)}")
+
+    return output
+
+
+def json_parse_list(jstr: str, *, strict_parsing: bool = False) -> list[Any]:
+    try:
+        lst = json.loads(jstr)
+    except ValueError:
+        if strict_parsing:
+            raise
+        return []
+
+    if not isinstance(lst, list):
+        if strict_parsing:
+            raise ValueError("JSON data does not contain a list")
+        return []
+
+    return lst
+
+
+def dict_add_optional(vdict: dict[T1, T2], key: T1, val: Optional[T2]) -> None:
+    if val is not None:
+        vdict[key] = val
+
+
+@typing.overload
+def dict_get_typed(
+    d: Mapping[Any, Any],
+    key: Any,
+    vtype: type[T],
+    *,
+    allow_missing: typing.Literal[False] = False,
+) -> T:
+    pass
+
+
+@typing.overload
+def dict_get_typed(
+    d: Mapping[Any, Any],
+    key: Any,
+    vtype: type[T],
+    *,
+    allow_missing: bool = False,
+) -> Optional[T]:
+    pass
+
+
+def dict_get_typed(
+    d: Mapping[Any, Any],
+    key: Any,
+    vtype: type[T],
+    *,
+    allow_missing: bool = False,
+) -> Optional[T]:
+    try:
+        v = d[key]
+    except KeyError:
+        if allow_missing:
+            return None
+        raise KeyError(f'missing key "{key}"')
+    if not isinstance(v, vtype):
+        raise TypeError(f'key "{key}" expected type {vtype} but has value "{v}"')
+    return v
+
+
+def serialize_enum(
+    data: Union[Enum, dict[Any, Any], list[Any], Any]
+) -> Union[str, dict[Any, Any], list[Any], Any]:
+    if isinstance(data, Enum):
+        return data.name
+    elif isinstance(data, dict):
+        return {k: serialize_enum(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [serialize_enum(item) for item in data]
+    else:
+        return data
+
+
+def dataclass_to_dict(obj: "DataclassInstance") -> dict[str, Any]:
+    d = dataclasses.asdict(obj)
+    return typing.cast(dict[str, Any], serialize_enum(d))
+
+
+def dataclass_to_json(obj: "DataclassInstance") -> str:
+    d = dataclass_to_dict(obj)
+    return json.dumps(d)
+
+
+# Takes a dataclass and the dict you want to convert from
+# If your dataclass has a dataclass member, it handles that recursively
+def dataclass_from_dict(cls: Type[T], data: dict[str, Any]) -> T:
+    if not is_dataclass(cls):
+        raise ValueError(
+            f"dataclass_from_dict() should only be used with dataclasses but is called with {cls}"
+        )
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"requires a dictionary to in initialize dataclass {cls} but got {type(data)}"
+        )
+    for k in data:
+        if not isinstance(k, str):
+            raise ValueError(
+                f"requires a strdict to in initialize dataclass {cls} but has key {type(k)}"
+            )
+    data = dict(data)
+    create_kwargs = {}
+    for field in fields(cls):
+        if field.name not in data:
+            if (
+                field.default is dataclasses.MISSING
+                and field.default_factory is dataclasses.MISSING
+            ):
+                raise ValueError(
+                    f'Missing mandatory argument "{field.name}" for dataclass {cls}'
+                )
+            continue
+
+        if not field.init:
+            continue
+
+        def convert_simple(ck_type: Any, value: Any) -> Any:
+            if is_dataclass(ck_type) and isinstance(value, dict):
+                return dataclass_from_dict(ck_type, value)
+            if actual_type is None and issubclass(ck_type, Enum):
+                return enum_convert(ck_type, value)
+            if ck_type is float and isinstance(value, int):
+                return float(value)
+            return value
+
+        actual_type = typing.get_origin(field.type)
+
+        value = data.pop(field.name)
+
+        converted = False
+
+        if actual_type is typing.Union:
+            # This is an Optional[]. We already have a value, we check for the requested
+            # type. check_type() already implements this, but we need to also check
+            # it here, for the dataclass/enum handling below.
+            args = typing.get_args(field.type)
+            ck_type = None
+            if len(args) == 2:
+                NoneType = type(None)
+                if args[0] is NoneType:
+                    ck_type = args[1]
+                elif args[1] is NoneType:
+                    ck_type = args[0]
+            if ck_type is not None:
+                value_converted = convert_simple(ck_type, value)
+                converted = True
+        elif actual_type is list:
+            args = typing.get_args(field.type)
+            if isinstance(value, list) and len(args) == 1:
+                value_converted = [convert_simple(args[0], v) for v in value]
+                converted = True
+
+        if not converted:
+            value_converted = convert_simple(field.type, value)
+
+        if not check_type(value_converted, field.type):
+            raise TypeError(
+                f"Expected type '{field.type}' for attribute '{field.name}' but received type '{type(value)}' ({value})"
+            )
+
+        create_kwargs[field.name] = value_converted
+
+    if data:
+        raise ValueError(
+            f"There are left over keys {list(data)} to create dataclass {cls}"
+        )
+
+    return cast(T, cls(**create_kwargs))
+
+
+def check_type(
+    value: typing.Any,
+    type_hint: Union[type[typing.Any], typing._SpecialForm],
+) -> bool:
+
+    # Some naive type checking. This is used for ensuring that data classes
+    # contain the expected types (see @strict_dataclass).
+    #
+    # That is most interesting, when we initialize the data class with
+    # data from an untrusted source (like elements from a JSON parser).
+
+    actual_type = typing.get_origin(type_hint)
+    if actual_type is None:
+        if isinstance(type_hint, str):
+            raise NotImplementedError(
+                f'Type hint "{type_hint}" as string is not implemented by check_type()'
+            )
+
+        if type_hint is typing.Any:
+            return True
+        return isinstance(value, typing.cast(Any, type_hint))
+
+    if actual_type is typing.Union:
+        args = typing.get_args(type_hint)
+        return any(check_type(value, a) for a in args)
+
+    if actual_type is list:
+        args = typing.get_args(type_hint)
+        (arg,) = args
+        return isinstance(value, list) and all(check_type(v, arg) for v in value)
+
+    if actual_type is dict or actual_type is Mapping:
+        args = typing.get_args(type_hint)
+        (arg_key, arg_val) = args
+        return isinstance(value, dict) and all(
+            check_type(k, arg_key) and check_type(v, arg_val) for k, v in value.items()
+        )
+
+    if actual_type is tuple:
+        # https://docs.python.org/3/library/typing.html#annotating-tuples
+        if not isinstance(value, tuple):
+            return False
+        args = typing.get_args(type_hint)
+        if len(args) == 1 and args[0] == ():
+            # This is an empty tuple tuple[()].
+            return len(value) == 0
+        if len(args) == 2 and args[1] is ...:
+            # This is a tuple[T, ...].
+            return all(check_type(v, args[0]) for v in value)
+        return len(value) == len(args) and all(
+            check_type(v, args[idx]) for idx, v in enumerate(value)
+        )
+
+    raise NotImplementedError(
+        f'Type hint "{type_hint}" with origin type "{actual_type}" is not implemented by check_type()'
+    )
+
+
+def dataclass_check(
+    instance: "DataclassInstance",
+    *,
+    with_post_check: bool = True,
+) -> None:
+
+    for field in dataclasses.fields(instance):
+        value = getattr(instance, field.name)
+        if not check_type(value, field.type):
+            raise TypeError(
+                f"Expected type '{field.type}' for attribute '{field.name}' but received type '{type(value)}' ({value})"
+            )
+
+    if with_post_check:
+        # Normally, data classes support __post_init__(), which is called by __init__()
+        # already. Add a way for a @strict_dataclass to add additional validation *after*
+        # the original check.
+        _post_check = getattr(type(instance), "_post_check", None)
+        if _post_check is not None:
+            _post_check(instance)
+
+
+def strict_dataclass(cls: TCallable) -> TCallable:
+
+    init = getattr(cls, "__init__")
+
+    def wrapped_init(self: Any, *args: Any, **argv: Any) -> None:
+        init(self, *args, **argv)
+        dataclass_check(self)
+
+    setattr(cls, "__init__", wrapped_init)
+    return cls
+
+
+def structparse_check_strdict(arg: Any, yamlpath: str) -> dict[str, Any]:
+    if not isinstance(arg, dict):
+        raise ValueError(f'"{yamlpath}": expects a dictionary but got {type(arg)}')
+    for k, v in arg.items():
+        if not isinstance(k, str):
+            raise ValueError(
+                f'"{yamlpath}": expects all dictionary keys to be strings but got {type(k)}'
+            )
+
+    # We shallow-copy the dictionary, because the caller will remove entries
+    # to find unknown entries (see _check_empty_dict()).
+    return dict(arg)
+
+
+def structparse_check_empty_dict(vdict: dict[str, Any], yamlpath: str) -> None:
+    length = len(vdict)
+    if length == 1:
+        raise ValueError(f'"{yamlpath}": unknown key "{list(vdict)[0]}"')
+    if length > 1:
+        raise ValueError(f'"{yamlpath}": unknown keys {list(vdict)}')
+
+
+def structparse_check_and_pop_name(
+    vdict: dict[str, Any], yamlpath: str, *, required: bool = False
+) -> Optional[str]:
+    name = vdict.pop("name", None)
+    if name is None:
+        if required:
+            raise ValueError(f'"{yamlpath}.name": mandatory key missing')
+        return None
+    if not isinstance(name, str):
+        raise ValueError(f'"{yamlpath}.name": expects a string but got {name}')
+    return name
+
+
+def structparse_check_and_pop_name_required(
+    vdict: dict[str, Any], yamlpath: str
+) -> str:
+    return typing.cast(
+        str, structparse_check_and_pop_name(vdict, yamlpath, required=True)
+    )
+
+
+@strict_dataclass
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class StructParseBase(abc.ABC):
+    yamlpath: str
+    yamlidx: int
+
+    @abc.abstractmethod
+    def serialize(self) -> Union[dict[str, Any], list[Any]]:
+        pass
+
+    def serialize_json(self) -> str:
+        return json.dumps(self.serialize())
+
+
+@strict_dataclass
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class StructParseBaseNamed(StructParseBase, abc.ABC):
+    name: str
+
+    def serialize(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+        }
+
+
+def repeat_for_same_result(fcn: TCallable) -> TCallable:
+    # This decorator wraps @fcn and will call it (up to 10 times) until the
+    # same result was returned twice in a row. The purpose is when we fetch
+    # several pieces of information form the system, that can change at any
+    # time. We would like to get a stable, self-consistent result.
+    @functools.wraps(fcn)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        result = None
+        for i in range(10):
+            new_result = fcn(*args, **kwargs)
+            if i != 0 and result == new_result:
+                return new_result
+            result = new_result
+        return result
+
+    return typing.cast(TCallable, wrapped)
+
+
+def etc_hosts_update_data(
+    content: str,
+    new_entries: Mapping[str, tuple[str, Optional[Iterable[str]]]],
+) -> str:
+
+    lineregex = re.compile(r"^\s*[a-fA-F0-9:.]+\s+([-a-zA-Z0-9_.]+)(\s+.*)?$")
+
+    def _unpack(
+        v: tuple[str, Optional[Iterable[str]]]
+    ) -> Union[typing.Literal[False], tuple[str, tuple[str, ...]]]:
+        n, a = v
+        if a is None:
+            a = ()
+        else:
+            a = tuple(a)
+        return n, a
+
+    entries = {k: _unpack(v) for k, v in new_entries.items()}
+
+    def _build_line(name: str, ipaddr: str, aliases: tuple[str, ...]) -> str:
+        if aliases:
+            s_aliases = f" {' '.join(aliases)}"
+        else:
+            s_aliases = ""
+        return f"{ipaddr} {name}{s_aliases}"
+
+    result = []
+    for line in content.splitlines():
+        m = lineregex.search(line)
+        if m:
+            name = m.group(1)
+            entry = entries.get(name)
+            if entry is None:
+                pass
+            elif entry is False:
+                continue
+            else:
+                line = _build_line(name, *entry)
+                entries[name] = False
+        result.append(line)
+
+    entries2 = [(k, v) for k, v in entries.items() if v is not False]
+    if entries2:
+        if result and result[-1] != "":
+            result.append("")
+        for name, entry in entries2:
+            result.append(_build_line(name, *entry))
+
+    if not result:
+        return ""
+
+    result.append("")
+    return "\n".join(result)
+
+
+def etc_hosts_update_file(
+    new_entries: Mapping[str, tuple[str, Optional[Iterable[str]]]],
+    filename: PathType = "/etc/hosts",
+) -> str:
+    try:
+        with open(filename, "rb") as f:
+            b_content = f.read()
+    except Exception:
+        b_content = b""
+
+    new_content = etc_hosts_update_data(
+        b_content.decode("utf-8", errors="surrogateescape"),
+        new_entries,
+    )
+
+    with open(filename, "wb") as f:
+        f.write(new_content.encode("utf-8", errors="surrogateescape"))
+
+    return new_content
+
+
+class Serial:
+    def __init__(self, port: str, baudrate: int = 115200):
+        import serial
+        from .logger import logger
+
+        self.port = port
+        self._ser = serial.Serial(port, baudrate=baudrate, timeout=0)
+        self._logger = logger
+        self._buffer = ""
+
+    @property
+    def buffer(self) -> str:
+        return self._buffer
+
+    def close(self) -> None:
+        self._ser.close()
+
+    def send(self, msg: str, *, sleep: float = 1) -> None:
+        self._logger.debug(f"serial[{self.port}]: send {repr(msg)}")
+        self._ser.write(msg.encode("utf-8", errors="surrogateescape"))
+        time.sleep(sleep)
+
+    def read_all(self) -> str:
+        maxsize = 1000000
+        while True:
+            buf: bytes = self._ser.read(maxsize)
+            self._buffer += buf.decode("utf-8", errors="surrogateescape")
+            if len(buf) < maxsize:
+                return self._buffer
+
+    def expect(
+        self,
+        pattern: Union[str, re.Pattern[str]],
+        timeout: float = 30,
+    ) -> str:
+        import select
+
+        end_timestamp = time.monotonic() + timeout
+        first_run = True
+
+        self._logger.debug(f"serial[{self.port}]: expect message {repr(pattern)}")
+
+        if isinstance(pattern, str):
+            # We use DOTALL like pexpect does.
+            # If you need something else, compile the pattern yourself.
+            #
+            # See also https://pexpect.readthedocs.io/en/stable/overview.html#find-the-end-of-line-cr-lf-conventions
+            pattern_re = re.compile(pattern, re.DOTALL)
+        else:
+            pattern_re = pattern
+
+        while True:
+
+            # First, read all data from the serial port that is currently available.
+            while True:
+                b: bytes = self._ser.read(100)
+                if not b:
+                    break
+                s = b.decode("utf-8", errors="surrogateescape")
+                self._logger.debug(
+                    f"serial[{self.port}]: read buffer ({len(self._buffer)} + {len(s)} unicode characters): {repr(s)}"
+                )
+                self._buffer += s
+
+            matches = re.finditer(pattern_re, self._buffer)
+            for match in matches:
+                end_idx = match.end()
+                self._logger.debug(
+                    f"serial[{self.port}]: found expected message {end_idx} unicode characters, {len(self._buffer) - end_idx} remaning"
+                )
+                self._buffer = self._buffer[end_idx:]
+                return self._buffer
+
+            if first_run:
+                first_run = False
+            else:
+                remaining_time = end_timestamp - time.monotonic()
+                if remaining_time <= 0:
+                    self._logger.debug(
+                        f"serial[{self.port}]: did not find expected message {repr(pattern)} (buffer content is {repr(self._buffer)})"
+                    )
+                    raise RuntimeError(
+                        f"Did not receive expected message {repr(pattern)} within timeout (buffer content is {repr(self._buffer)})"
+                    )
+                _, _, _ = select.select([self._ser], [], [], remaining_time)
+
+    def __enter__(self) -> "Serial":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional["TracebackType"],
+    ) -> None:
+        self._ser.close()

--- a/ktoolbox/firewall.py
+++ b/ktoolbox/firewall.py
@@ -1,0 +1,60 @@
+import shlex
+
+from . import host
+
+
+def _nft_cmd_table(*, up: bool, family: str, table_name: str) -> str:
+    return (
+        f"add table {family} {table_name}\n"
+        f"{'flush' if up else 'delete'} table {family} {table_name}\n"
+    )
+
+
+def nft_data_delete_table(
+    *,
+    family: str,
+    table_name: str,
+) -> str:
+    return _nft_cmd_table(up=False, family=family, table_name=table_name)
+
+
+def nft_data_masquerade_down(
+    table_name: str,
+) -> str:
+    return nft_data_delete_table(family="ip", table_name=table_name)
+
+
+def nft_data_masquerade_up(
+    *,
+    table_name: str,
+    subnet: str,
+    ifname: str,
+) -> str:
+    # Taken from NetworkManager:
+    # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/8488162d1069defada6be0666175ffd10f333f9d/src/core/nm-firewall-utils.c#L688
+    return _nft_cmd_table(up=True, family="ip", table_name=table_name) + (
+        f"add chain ip {table_name} nat_postrouting {{"
+        " type nat hook postrouting priority 100; policy accept; "
+        "};\n"
+        f"add rule ip {table_name} nat_postrouting ip saddr {subnet} ip daddr != {subnet} masquerade;\n"
+        f"add chain ip {table_name} filter_forward {{"
+        " type filter hook forward priority 0; policy accept; "
+        "};\n"
+        f'add rule ip {table_name} filter_forward ip daddr {subnet} oifname "{ifname}" '
+        " ct state { established, related } accept;\n"
+        f'add rule ip {table_name} filter_forward ip saddr {subnet} iifname "{ifname}" accept;\n'
+        f'add rule ip {table_name} filter_forward iifname "{ifname}" oifname "{ifname}" accept;\n'
+        f'add rule ip {table_name} filter_forward iifname "{ifname}" reject;\n'
+        f'add rule ip {table_name} filter_forward oifname "{ifname}" reject;\n'
+    )
+
+
+def nft_call(
+    data: str,
+    rsh: host.Host = host.local,
+    *,
+    nft_cmd: str = "nft",
+) -> bool:
+    return rsh.run(
+        f"printf '%s' {shlex.quote(data)} | {shlex.quote(nft_cmd)} -f -"
+    ).success

--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -1,0 +1,518 @@
+import dataclasses
+import logging
+import os
+import shlex
+import subprocess
+import sys
+import threading
+import typing
+
+from abc import ABC
+from abc import abstractmethod
+from collections.abc import Iterable
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Union
+
+from .logger import logger
+
+INTERNAL_ERROR_PREFIX = "Host.run(): "
+INTERNAL_ERROR_RETURNCODE = 1
+
+
+_lock = threading.Lock()
+
+_unique_log_id_value = 0
+
+# Same as common.KW_ONLY_DATACLASS, but we should not use common module here.
+# See common.KW_ONLY_DATACLASS why this is used.
+KW_ONLY_DATACLASS = {"kw_only": True} if "kw_only" in dataclass.__kwdefaults__ else {}
+
+
+def _normalize_cmd(
+    cmd: Union[str, Iterable[str]],
+) -> Union[str, tuple[str, ...]]:
+    if isinstance(cmd, str):
+        return cmd
+    else:
+        return tuple(cmd)
+
+
+def _normalize_env(
+    env: Optional[Mapping[str, Optional[str]]],
+) -> Optional[dict[str, Optional[str]]]:
+    if env is None:
+        return None
+    return dict(env)
+
+
+def _cmd_to_logstr(cmd: Union[str, tuple[str, ...]]) -> str:
+    return repr(_cmd_to_shell(cmd))
+
+
+def _cmd_to_shell(cmd: Union[str, Iterable[str]]) -> str:
+    if isinstance(cmd, str):
+        return cmd
+    return shlex.join(cmd)
+
+
+def _cmd_to_argv(cmd: Union[str, Iterable[str]]) -> tuple[str, ...]:
+    if isinstance(cmd, str):
+        return ("/bin/sh", "-c", cmd)
+    return tuple(cmd)
+
+
+def _prepare_run(
+    *,
+    sudo: bool,
+    cwd: Optional[str],
+    cmd: Union[str, Iterable[str]],
+    env: Optional[Mapping[str, Optional[str]]],
+) -> tuple[
+    Union[str, tuple[str, ...]],
+    Optional[dict[str, Optional[str]]],
+    Optional[str],
+]:
+    if not sudo:
+        return (
+            _normalize_cmd(cmd),
+            _normalize_env(env),
+            cwd,
+        )
+
+    cmd2 = ["sudo"]
+
+    if env:
+        for k, v in env.items():
+            assert k == shlex.quote(k)
+            assert "=" not in k
+            if v is not None:
+                cmd2.append(f"{k}={v}")
+
+    if cwd is not None:
+        # sudo's "--chdir" option often does not work based on the sudo
+        # configuration.  Instead, change the directory inside the shell
+        # script.
+        cmd = f"cd {shlex.quote(cwd)} || exit 1 ; {_cmd_to_shell(cmd)}"
+
+    cmd2.extend(_cmd_to_argv(cmd))
+
+    return tuple(cmd2), None, None
+
+
+def _unique_log_id() -> int:
+    # For each run() call, we log a message when starting the command and when
+    # completing it. Add a unique number to those logging statements, so that
+    # we can easier find them in a large log.
+    with _lock:
+        global _unique_log_id_value
+        _unique_log_id_value += 1
+        return _unique_log_id_value
+
+
+T = typing.TypeVar("T", bound=Union[str, bytes])
+
+
+@dataclass(frozen=True)
+class _BaseResult(ABC, typing.Generic[T]):
+    # _BaseResult only exists to have the first 3 parameters positional
+    # arguments and the subsequent parameters (in BaseResult) marked as
+    # KW_ONLY_DATACLASS. Once we no longer support Python 3.9, the classes
+    # can be merged.
+    out: T
+    err: T
+    returncode: int
+
+
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class BaseResult(_BaseResult[T]):
+    # In most cases, "success" is the same as checking for returncode zero.  In
+    # some cases, it can be overwritten to be of a certain value.
+    forced_success: Optional[bool] = dataclasses.field(
+        default=None,
+        # kw_only=True <- use once we upgrade to 3.10 and drop KW_ONLY_DATACLASS.
+    )
+
+    @property
+    def success(self) -> bool:
+        if self.forced_success is not None:
+            return self.forced_success
+        return self.returncode == 0
+
+    def debug_str(self) -> str:
+        if self.forced_success is None or self.forced_success == (self.returncode == 0):
+            if self.success:
+                status = "success"
+            else:
+                status = f"failed (exit {self.returncode})"
+        else:
+            if self.forced_success:
+                status = f"success [forced] (exit {self.returncode})"
+            else:
+                status = "failed [forced] (exit 0)"
+
+        out = ""
+        if self.out:
+            out = f"; out={repr(self.out)}"
+
+        err = ""
+        if self.err:
+            err = f"; err={repr(self.err)}"
+
+        return f"{status}{out}{err}"
+
+    def debug_msg(self) -> str:
+        return f"cmd {self.debug_str()}"
+
+
+@dataclass(frozen=True)
+class Result(BaseResult[str]):
+    pass
+
+
+@dataclass(frozen=True)
+class BinResult(BaseResult[bytes]):
+    def decode(self, errors: str = "strict") -> Result:
+        return Result(
+            self.out.decode(errors=errors),
+            self.err.decode(errors=errors),
+            self.returncode,
+        )
+
+
+class Host(ABC):
+    def __init__(
+        self,
+        *,
+        sudo: bool = False,
+    ) -> None:
+        self._sudo = sudo
+
+    @abstractmethod
+    def pretty_str(self) -> str:
+        pass
+
+    @typing.overload
+    def run(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        text: typing.Literal[True] = True,
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        sudo: Optional[bool] = None,
+        cwd: Optional[str] = None,
+        log_prefix: str = "",
+        log_level: int = logging.DEBUG,
+        log_level_result: Optional[int] = None,
+        log_level_fail: Optional[int] = None,
+        check_success: Optional[Callable[[Result], bool]] = None,
+        die_on_error: bool = False,
+        decode_errors: Optional[str] = None,
+    ) -> Result:
+        pass
+
+    @typing.overload
+    def run(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        text: typing.Literal[False],
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        sudo: Optional[bool] = None,
+        cwd: Optional[str] = None,
+        log_prefix: str = "",
+        log_level: int = logging.DEBUG,
+        log_level_result: Optional[int] = None,
+        log_level_fail: Optional[int] = None,
+        check_success: Optional[Callable[[BinResult], bool]] = None,
+        die_on_error: bool = False,
+        decode_errors: Optional[str] = None,
+    ) -> BinResult:
+        pass
+
+    @typing.overload
+    def run(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        text: bool = True,
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        sudo: Optional[bool] = None,
+        cwd: Optional[str] = None,
+        log_prefix: str = "",
+        log_level: int = logging.DEBUG,
+        log_level_result: Optional[int] = None,
+        log_level_fail: Optional[int] = None,
+        check_success: Optional[
+            Union[Callable[[Result], bool], Callable[[BinResult], bool]]
+        ] = None,
+        die_on_error: bool = False,
+        decode_errors: Optional[str] = None,
+    ) -> Union[Result, BinResult]:
+        pass
+
+    def run(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        text: bool = True,
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        sudo: Optional[bool] = None,
+        cwd: Optional[str] = None,
+        log_prefix: str = "",
+        log_level: int = logging.DEBUG,
+        log_level_result: Optional[int] = None,
+        log_level_fail: Optional[int] = None,
+        check_success: Optional[
+            Union[Callable[[Result], bool], Callable[[BinResult], bool]]
+        ] = None,
+        die_on_error: bool = False,
+        decode_errors: Optional[str] = None,
+    ) -> Union[Result, BinResult]:
+        log_id = _unique_log_id()
+
+        if sudo is None:
+            sudo = self._sudo
+
+        real_cmd, real_env, real_cwd = _prepare_run(
+            sudo=sudo,
+            cwd=cwd,
+            cmd=cmd,
+            env=env,
+        )
+
+        if log_level >= 0:
+            logger.log(
+                log_level,
+                f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: call {_cmd_to_logstr(real_cmd)}",
+            )
+
+        bin_result = self._run(
+            cmd=real_cmd,
+            env=real_env,
+            cwd=real_cwd,
+        )
+
+        # The remainder is only concerned with printing a nice logging message and
+        # (potentially) decode the binary output.
+
+        str_result: Optional[Result] = None
+        unexpected_binary = False
+        is_binary = True
+        decode_exception: Optional[Exception] = None
+        if text:
+            # The caller requested string (Result) output. "decode_errors" control what we do.
+            #
+            # - None (the default). We effectively use "errors='replace'"). On any encoding
+            #   error we log an ERROR message.
+            # - otherwise, we use "decode_errors" as requested. An encoding error will not
+            #   raise the log level, but we will always log the result. We will even log
+            #   the result if the decoding results in an exception (see decode_exception).
+            try:
+                # We first always try to decode strictly to find out whether
+                # it's valid utf-8.
+                str_result = bin_result.decode(errors="strict")
+            except UnicodeError as e:
+                if decode_errors == "strict":
+                    decode_exception = e
+                is_binary = True
+            else:
+                is_binary = False
+
+            if decode_exception is not None:
+                # We had an error. We keep this and re-raise later.
+                pass
+            elif not is_binary and (
+                decode_errors is None
+                or decode_errors in ("strict", "ignore", "replace", "surrogateescape")
+            ):
+                # We are good. The output is not binary, and the caller did not
+                # request some unusual decoding. We already did the decoding.
+                pass
+            elif decode_errors is not None:
+                # Decode again, this time with the decoding option requested
+                # by the caller.
+                try:
+                    str_result = bin_result.decode(errors=decode_errors)
+                except UnicodeError as e:
+                    decode_exception = e
+            else:
+                # We have a binary and the caller didn't specify a special
+                # encoding. We use "replace" fallback, but set a flag that
+                # we have unexpected_binary (and lot an ERROR below).
+                str_result = bin_result.decode(errors="replace")
+                unexpected_binary = True
+
+        if check_success is None:
+            result_success = bin_result.success
+        else:
+            result_success = True
+            if text:
+                str_check = typing.cast(Callable[[Result], bool], check_success)
+                if str_result is None:
+                    # This can only happen in text mode when the caller specified
+                    # a "decode_errors" that resulted in a "decode_exception".
+                    # The function will raise an exception, and we won't call
+                    # the check_success() handler.
+                    #
+                    # Avoid this by using text=False or a "decode_errors" value
+                    # that does not fail.
+                    result_success = False
+                elif not str_check(str_result):
+                    result_success = False
+            else:
+                bin_check = typing.cast(Callable[[BinResult], bool], check_success)
+                if not bin_check(bin_result):
+                    result_success = False
+
+        status_msg = ""
+        if log_level_fail is not None and not result_success:
+            result_log_level = log_level_fail
+        elif log_level_result is not None:
+            result_log_level = log_level_result
+        else:
+            result_log_level = log_level
+
+        if die_on_error and not result_success:
+            if result_log_level < logging.ERROR:
+                result_log_level = logging.ERROR
+            status_msg += " [FATAL]"
+
+        if text and is_binary:
+            status_msg += " [BINARY]"
+
+        if decode_exception:
+            # We caught an exception during decoding. We still want to log the result,
+            # before re-raising the exception.
+            #
+            # We don't increase the logging level, because the user requested a special
+            # "decode_errors". A decoding error is expected, we just want to log about it
+            # (with the level we would have).
+            status_msg += " [DECODE_ERROR]"
+
+        if unexpected_binary:
+            status_msg += " [UNEXPECTED_BINARY]"
+            if result_log_level < logging.ERROR:
+                result_log_level = logging.ERROR
+
+        if str_result is not None:
+            if result_success != str_result.success:
+                str_result = Result(
+                    out=str_result.out,
+                    err=str_result.err,
+                    returncode=str_result.returncode,
+                    forced_success=result_success,
+                )
+        if result_success != bin_result.success:
+            bin_result = BinResult(
+                out=bin_result.out,
+                err=bin_result.err,
+                returncode=bin_result.returncode,
+                forced_success=result_success,
+            )
+
+        if is_binary:
+            # Note that we log the output as binary if either "text=False" or if
+            # the output was not valid utf-8. In the latter case, we will still
+            # return a string Result (or re-raise decode_exception).
+            debug_str = bin_result.debug_str()
+        else:
+            assert str_result is not None
+            debug_str = str_result.debug_str()
+
+        if result_log_level >= 0:
+            logger.log(
+                result_log_level,
+                f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: └──> {_cmd_to_logstr(real_cmd)}:{status_msg} {debug_str}",
+            )
+
+        if decode_exception:
+            raise decode_exception
+
+        if die_on_error and not result_success:
+            import traceback
+
+            logger.error(
+                f"FATAL ERROR. BACKTRACE:\n{''.join(traceback.format_stack())}"
+            )
+            sys.exit(-1)
+
+        if str_result is not None:
+            return str_result
+        return bin_result
+
+    @abstractmethod
+    def _run(
+        self,
+        *,
+        cmd: Union[str, tuple[str, ...]],
+        env: Optional[dict[str, Optional[str]]],
+        cwd: Optional[str],
+    ) -> BinResult:
+        pass
+
+    def file_exists(self, path: Union[str, os.PathLike[Any]]) -> bool:
+        return self.run(["test", "-e", str(path)], log_level=-1, text=False).success
+
+
+class LocalHost(Host):
+    def pretty_str(self) -> str:
+        return "localhost"
+
+    def _run(
+        self,
+        *,
+        cmd: Union[str, tuple[str, ...]],
+        env: Optional[dict[str, Optional[str]]],
+        cwd: Optional[str],
+    ) -> BinResult:
+        full_env: Optional[dict[str, str]] = None
+        if env is not None:
+            full_env = os.environ.copy()
+            for k, v in env.items():
+                if v is None:
+                    full_env.pop(k, None)
+                else:
+                    full_env[k] = v
+
+        try:
+            res = subprocess.run(
+                cmd,
+                shell=isinstance(cmd, str),
+                capture_output=True,
+                env=full_env,
+                cwd=cwd,
+            )
+        except Exception as e:
+            # We get an FileNotFoundError if cwd directory does not exist or if
+            # the binary does not exist (with shell=False). We get a PermissionError
+            # if we don't have permissions.
+            #
+            # Generally, we don't want to report errors via exceptions, because
+            # you won't get the same exception with shell=True. Instead, we
+            # only report errors via BinResult().
+            #
+            # Usually we avoid creating an artificial BinResult. In this case
+            # there is no choice.
+            return BinResult(
+                b"",
+                (INTERNAL_ERROR_PREFIX + str(e)).encode(errors="surrogateescape"),
+                INTERNAL_ERROR_RETURNCODE,
+            )
+
+        return BinResult(res.stdout, res.stderr, res.returncode)
+
+    def file_exists(self, path: Union[str, os.PathLike[Any]]) -> bool:
+        return os.path.exists(path)
+
+
+local = LocalHost()
+
+
+def host_or_local(host: Optional[Host]) -> Host:
+    if host is None:
+        return local
+    return host

--- a/ktoolbox/k8sClient.py
+++ b/ktoolbox/k8sClient.py
@@ -1,0 +1,201 @@
+import json
+import logging
+import os
+import random
+import shlex
+import sys
+import typing
+import yaml
+
+from collections.abc import Iterable
+from typing import Union
+
+from . import host
+from .logger import logger
+
+
+class K8sClient:
+    def __init__(self, kubeconfig: typing.Optional[str] = None):
+        if kubeconfig is None:
+            kubeconfig = os.getenv("KUBECONFIG")
+            if not kubeconfig:
+                raise RuntimeError(
+                    "KUBECONFIG environment variable not set and no kubeconfig argument specified"
+                )
+
+        if not os.path.exists(kubeconfig):
+            raise RuntimeError(
+                f"KUBECONFIG={shlex.quote(kubeconfig)} file does not exist"
+            )
+        # Load the file to check that it is valid YAML.
+        with open(kubeconfig) as f:
+            yaml.safe_load(f)
+
+        self.kubeconfig = kubeconfig
+
+    @staticmethod
+    def _get_oc_cmd(cmd: Union[str, Iterable[str]]) -> list[str]:
+        if isinstance(cmd, str):
+            return shlex.split(cmd)
+        return list(cmd)
+
+    def _get_oc_cmd_full(
+        self,
+        *,
+        cmd: Union[str, Iterable[str]],
+        namespace: typing.Optional[str] = None,
+    ) -> list[str]:
+        namespace_args: tuple[str, ...]
+        if namespace:
+            namespace_args = ("-n", namespace)
+        else:
+            namespace_args = ()
+        return [
+            "kubectl",
+            "--kubeconfig",
+            self.kubeconfig,
+            *namespace_args,
+            *self._get_oc_cmd(cmd),
+        ]
+
+    def oc(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        check_success: typing.Optional[typing.Callable[[host.Result], bool]] = None,
+        namespace: typing.Optional[str] = None,
+    ) -> host.Result:
+        return host.local.run(
+            self._get_oc_cmd_full(cmd=cmd, namespace=namespace),
+            die_on_error=die_on_error,
+            check_success=check_success,
+            log_level_fail=logging.DEBUG if may_fail else logging.ERROR,
+        )
+
+    def oc_exec(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        pod_name: str,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        namespace: typing.Optional[str] = None,
+    ) -> host.Result:
+        return self.oc(
+            ["exec", pod_name, "--", *self._get_oc_cmd(cmd)],
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+    def oc_get(
+        self,
+        what: str,
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        namespace: typing.Optional[str] = None,
+    ) -> typing.Optional[dict[str, typing.Any]]:
+        cmd = ["get", what, "-o", "json"]
+        ret = self.oc(
+            cmd,
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+        if not ret.success:
+            # No need for extra logging in this failure case. self.oc() already
+            # did all the logging we want.
+            return None
+
+        try:
+            data = json.loads(ret.out)
+        except ValueError:
+            data = None
+
+        if not isinstance(data, dict):
+            cmd_s = shlex.join(self._get_oc_cmd_full(cmd=cmd, namespace=namespace))
+            if not may_fail or die_on_error:
+                logger.error(
+                    f"Command {cmd_s} did not return a JSON dictionary but {ret.debug_str()}"
+                )
+            else:
+                logger.debug(f"Command {cmd_s} did not return a JSON dictionary")
+            if die_on_error:
+                sys.exit(-1)
+            return None
+
+        return data
+
+    def oc_debug(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        node_name: str,
+        test_image: str,
+        namespace: str,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+    ) -> host.Result:
+        container_name = f"ocp-tft-debug-{node_name}-{random.randint(0, 2**64-1):016x}"
+        # We use `kubectl debug` and not `oc debug`. There are thus some differences.
+        #
+        # Optimally, we would use "--profile=sysadmin". But that is too new, so
+        # we cannot use it and have no CAP_SYS_CHROOT.  That means, `cmd`
+        # cannot be `chroot /host crictl ...` but needs to be
+        # `/host/usr/bin/crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ...`.
+        #
+        # Also, unlike `oc debug`, we need an "--image", which the caller must specify.
+        #
+        # Also, we must specify a namespace. And the container will linger around afterwards,
+        # so we need to delete it (below).
+        result = self.oc(
+            [
+                "debug",
+                "-q",
+                "-ti",
+                "--profile=general",
+                f"--container={container_name}",
+                f"--image={test_image}",
+                f"node/{node_name}",
+                "--",
+                *self._get_oc_cmd(cmd),
+            ],
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+        # We have to find and delete the pods we just created. As we used
+        # a unique {container_name}, we can search for that.
+        pod_names = []
+        pdict = self.oc_get(
+            "pods",
+            may_fail=True,
+            namespace=namespace,
+        )
+        pdict_items = []
+        if pdict is not None:
+            try:
+                pdict_items = list(pdict["items"])
+            except Exception:
+                pass
+        for pdict_item in pdict_items:
+            try:
+                for c in pdict_item["spec"]["containers"]:
+                    if c["name"] == container_name:
+                        pod_names.append(pdict_item["metadata"]["name"])
+                        break
+            except Exception:
+                pass
+        for pod_name in pod_names:
+            self.oc(
+                ["delete", "--wait=false", f"pod/{pod_name}"],
+                may_fail=True,
+                namespace=namespace,
+            )
+
+        return result

--- a/ktoolbox/logger.py
+++ b/ktoolbox/logger.py
@@ -1,0 +1,28 @@
+import logging
+
+from typing import Optional
+from typing import TextIO
+
+
+def configure_logger(lvl: int) -> None:
+    global logger
+    logger.setLevel(lvl)
+
+    fmt = "%(asctime)s.%(msecs)03d %(levelname)-7s [th:%(thread)s]: %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    formatter = logging.Formatter(fmt, datefmt)
+
+    handler = logging.StreamHandler()
+    handler.setLevel(lvl)
+    handler.setFormatter(formatter)
+
+    global prev_handler
+    if prev_handler is not None:
+        logger.removeHandler(prev_handler)
+    prev_handler = handler
+    logger.addHandler(handler)
+
+
+prev_handler: Optional["logging.StreamHandler[TextIO]"] = None
+logger = logging.getLogger("CDA")
+configure_logger(logging.DEBUG)

--- a/ktoolbox/netdev.py
+++ b/ktoolbox/netdev.py
@@ -1,0 +1,1001 @@
+import json
+import os
+import re
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+from typing import Optional
+from typing import Union
+
+from . import host
+from . import common
+
+from .common import strict_dataclass
+from .common import dict_add_optional
+
+
+def _parse_line(line: str, caption: str) -> Optional[str]:
+    if line.startswith(caption):
+        return line[len(caption) :]
+    return None
+
+
+_isspace_kernel_set = {c[0] for c in (b" ", b"\n", b"\t", b"\r", b"\f", b"\v", b"\240")}
+
+
+def isspace_kernel(c: Union[int, bytes]) -> bool:
+    # mirrors kernel's isspace() from "include/linux/ctype.h", which treats as
+    # space the common ASCII spaces, including '\v' (vertical tab), but also
+    # '\240' (non-breaking space, NBSP in Latin-1). */
+    if isinstance(c, int):
+        if c < 0 or c > 255:
+            raise ValueError("Integer is not a valid byte")
+    elif isinstance(c, bytes):
+        if len(c) != 1:
+            raise ValueError("Requires a single byte as argument")
+        c = c[0]
+    else:
+        raise TypeError("Expects either an integer or a single byte")
+
+    return c in _isspace_kernel_set
+
+
+def normalize_ifname(
+    ifname: Union[str, bytes],
+    *,
+    validate: bool = False,
+    allow_reserved: bool = True,
+) -> bytes:
+    if isinstance(ifname, str):
+        ifname = ifname.encode("utf-8", errors="surrogateescape")
+    elif not isinstance(ifname, bytes):
+        raise TypeError(f"Unexpected ifname of type {type(ifname)}")
+
+    if validate:
+        if not ifname:
+            raise ValueError("Ifname cannot be empty")
+        if b"/" in ifname:
+            raise ValueError("Ifname cannot contain slash")
+        if ifname in (b".", b".."):
+            raise ValueError(f'Ifname cannot be "{ifname.decode()}"')
+        if len(ifname) > 15:
+            raise ValueError("Ifname cannot be longer than 15 characters")
+        if b":" in ifname:
+            raise ValueError("Ifname cannot contain colon")
+        for c in ifname:
+            if c == 0:
+                raise ValueError("Invalid zero bytes")
+            if isspace_kernel(c):
+                raise ValueError("Invalid white space")
+        if not allow_reserved:
+            # Certain modules create sysctl files that later prevent creating
+            # interfaces with those names. However, you can create those interfaces
+            # if the module is not loaded.
+            #
+            # You are advised to not use those interface names, but you can
+            # create such interfaces in kernel (if the conflicting module is
+            # not loaded).
+            #
+            # The "all" and "default" names are reserved
+            # due to their directories in "/proc/sys/net/ipv4/conf/" and "/proc/sys/net/ipv6/conf/".
+            # Also, there is "/sys/class/net/bonding_masters" file.
+            if ifname in (
+                b"all",
+                b"default",
+                b"bonding_masters",
+            ):
+                raise ValueError(f"Interface name {repr(ifname)} is reserved")
+
+    return ifname
+
+
+def validate_ifname(
+    ifname: Union[str, bytes],
+    *,
+    allow_reserved: bool = True,
+) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    #
+    # See also, dev_valid_name() in kernel.
+    ifname = normalize_ifname(ifname, validate=True, allow_reserved=allow_reserved)
+    return ifname.decode(errors="surrogateescape")
+
+
+def validate_ifname_or_none(ifname: Union[str, bytes]) -> Optional[str]:
+    try:
+        return validate_ifname(ifname)
+    except ValueError:
+        return None
+
+
+_pciaddr_re = re.compile("^[0-9a-f]{4}:[0-9a-f]{2}:[01][0-9a-f].[0-7]$")
+
+
+def validate_pciaddr(pciaddr: Union[str, bytes]) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    if isinstance(pciaddr, bytes):
+        try:
+            pciaddr = pciaddr.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError(
+                f"PCI address cannot contain non UTF-8 characters ({repr(pciaddr)})"
+            )
+    elif not isinstance(pciaddr, str):
+        raise TypeError(f"PCI address of unexpected type {type(pciaddr)}")
+    if not pciaddr:
+        raise ValueError("PCI address cannot be empty")
+    if not _pciaddr_re.search(pciaddr):
+        raise ValueError(f"PCI address contains invalid characters ({repr(pciaddr)})")
+    if pciaddr in (".", ".."):
+        raise ValueError(f'PCI address cannot be "{pciaddr}"')
+    return pciaddr
+
+
+_ethaddr_re = re.compile(
+    "^([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?)$"
+)
+
+
+def validate_ethaddr(ethaddr: Union[str, bytes]) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    if isinstance(ethaddr, bytes):
+        try:
+            ethaddr = ethaddr.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError(
+                f"Ethernet address cannot contain non UTF-8 characters ({repr(ethaddr)})"
+            )
+    elif not isinstance(ethaddr, str):
+        raise TypeError(f"Ethernet address of unexpected type {type(ethaddr)}")
+    m = _ethaddr_re.search(ethaddr)
+    if not m:
+        raise ValueError(
+            f"Ethernet address contains invalid characters ({repr(ethaddr)})"
+        )
+
+    def _normalize_hex(s: str) -> str:
+        s = s.lower()
+        if len(s) == 1:
+            return "0" + s
+        return s
+
+    ethaddr2 = ":".join(_normalize_hex(m.group(i)) for i in range(1, 7))
+    if ethaddr2 == ethaddr:
+        return ethaddr
+    return ethaddr2
+
+
+def validate_ethaddr_or_none(ethaddr: Union[str, bytes]) -> Optional[str]:
+    try:
+        return validate_ethaddr(ethaddr)
+    except ValueError:
+        return None
+
+
+def pciaddr_get_func_address(pciaddr: Optional[Union[str, bytes]]) -> Optional[int]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/master/sriovnet_switchdev.go#L172
+    if pciaddr is None:
+        return None
+
+    pciaddr = validate_pciaddr(pciaddr)
+
+    last_char = pciaddr[-1]
+    return int(last_char)
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class IPRouteAddressInfoEntry:
+    family: str
+    local: str
+
+    def _post_check(self) -> None:
+        if not isinstance(self.family, str) or self.family not in ("inet", "inet6"):
+            raise ValueError("Invalid address family")
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class IPRouteAddressEntry:
+    ifindex: int
+    ifname: str
+    flags: tuple[str, ...]
+    master: Optional[str]
+    address: str  # Ethernet address.
+    addr_info: tuple[IPRouteAddressInfoEntry, ...]
+
+    def has_carrier(self) -> bool:
+        return "NO-CARRIER" not in self.flags
+
+
+def ip_addrs_parse(
+    jstr: str,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+) -> list[IPRouteAddressEntry]:
+    ret: list[IPRouteAddressEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+            entry = IPRouteAddressEntry(
+                ifindex=e["ifindex"],
+                ifname=validate_ifname(e["ifname"]),
+                flags=tuple(e["flags"]),
+                master=e["master"] if "master" in e else None,
+                address=e["address"],
+                addr_info=tuple(
+                    IPRouteAddressInfoEntry(
+                        family=addr["family"],
+                        local=addr["local"],
+                    )
+                    for addr in e["addr_info"]
+                ),
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        if ifname is not None and normalize_ifname(ifname) != normalize_ifname(
+            entry.ifname
+        ):
+            continue
+        ret.append(entry)
+    return ret
+
+
+def ip_addrs(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+    ip_log_level: int = -1,
+) -> list[IPRouteAddressEntry]:
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json addr",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-route on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_addrs_parse(ret.out, strict_parsing=strict_parsing, ifname=ifname)
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class IPRouteLinkEntry:
+    ifindex: int
+    ifname: str
+    address: Optional[str]
+    permaddr: Optional[str]
+    flags: tuple[str, ...]
+    mtu: int
+    operstate: str
+    link_info_kind: Optional[str]
+
+    def match_ifname(self, ifname: Optional[Union[str, bytes]]) -> bool:
+        if ifname is None:
+            return False
+        return normalize_ifname(self.ifname) == normalize_ifname(ifname)
+
+
+def ip_links_parse(
+    jstr: str, *, strict_parsing: bool = False, ifname: Optional[str] = None
+) -> list[IPRouteLinkEntry]:
+    ret: list[IPRouteLinkEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+
+            link_info_kind: Optional[str] = None
+            link_info = e.get("linkinfo")
+            if link_info is not None:
+                link_info_kind = link_info.get("info_kind")
+
+            address = e.get("address")
+            if address is not None:
+                address = validate_ethaddr_or_none(address)
+
+            permaddr = e.get("permaddr")
+            if permaddr is not None:
+                permaddr = validate_ethaddr_or_none(permaddr)
+
+            entry = IPRouteLinkEntry(
+                ifindex=e["ifindex"],
+                ifname=validate_ifname(e["ifname"]),
+                mtu=int(e["mtu"]),
+                flags=tuple(e["flags"]),
+                operstate=(e["operstate"]),
+                link_info_kind=link_info_kind,
+                address=address,
+                permaddr=permaddr,
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        if ifname is not None and normalize_ifname(ifname) != normalize_ifname(
+            entry.ifname
+        ):
+            continue
+        ret.append(entry)
+    return ret
+
+
+def ip_links(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+    ip_log_level: int = -1,
+) -> list[IPRouteLinkEntry]:
+    # If @ifname is requested, we could issue a `ip -json link show $IFNAME`. However,
+    # that means we do different things for requesting one link vs. all links. That
+    # seems undesirable. Instead, in all cases fetch all links. Any filtering then happens
+    # in code that we control. Performance should not make a difference, since the JSON data
+    # is probably small anyway (compared to the overhead of invoking a shell command).
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json -d link",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-link on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_links_parse(ret.out, strict_parsing=strict_parsing, ifname=ifname)
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class IPRouteRouteEntry:
+    dst: str
+    dev: str
+
+
+def ip_routes_parse(
+    jstr: str,
+    *,
+    strict_parsing: bool = False,
+) -> list[IPRouteRouteEntry]:
+    ret: list[IPRouteRouteEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+            entry = IPRouteRouteEntry(
+                dst=e["dst"],
+                dev=validate_ifname(e["dev"]),
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        ret.append(entry)
+    return ret
+
+
+def ip_routes(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> list[IPRouteRouteEntry]:
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json route",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-route on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_routes_parse(ret.out, strict_parsing=strict_parsing)
+
+
+def ethtool_permaddr(
+    rsh: Optional[host.Host] = None,
+    *,
+    ifname: Union[str, bytes],
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> Optional[str]:
+    ifname = validate_ifname(ifname)
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        ["ethtool", "-P", ifname],
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+        env={"LANG": "C"},
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ethtool -P {repr(ifname)} failed ({ret})")
+        return None
+
+    permaddr: Optional[str] = None
+
+    for line in ret.out.splitlines():
+        if (x := _parse_line(line, "Permanent address: ")) is not None:
+            permaddr = x
+
+    if permaddr is None:
+        return None
+
+    return validate_ethaddr_or_none(permaddr)
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class EthtoolDriverInfo:
+    ifname: str
+    driver: Optional[str]
+    version: Optional[str]
+    firmware_version: Optional[str]
+
+
+def ethtool_driver(
+    rsh: Optional[host.Host] = None,
+    *,
+    ifname: Union[str, bytes],
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> Optional[EthtoolDriverInfo]:
+    ifname = validate_ifname(ifname)
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        ["ethtool", "-i", ifname],
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+        env={"LANG": "C"},
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ethtool -i {repr(ifname)} failed ({ret})")
+        return None
+
+    driver: Optional[str] = None
+    version: Optional[str] = None
+    firmware_version: Optional[str] = None
+
+    for line in ret.out.splitlines():
+        if (x := _parse_line(line, "driver: ")) is not None:
+            driver = x
+        elif (x := _parse_line(line, "version: ")) is not None:
+            version = x
+        elif (x := _parse_line(line, "firmware-version: ")) is not None:
+            firmware_version = x
+
+    return EthtoolDriverInfo(
+        ifname=ifname,
+        driver=driver,
+        version=version,
+        firmware_version=firmware_version,
+    )
+
+
+def _sysctl_parse_str(s: Optional[Union[str, bytes]]) -> Optional[str]:
+    if s is None:
+        return None
+
+    if isinstance(s, bytes):
+        try:
+            s = s.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return None
+
+    if not isinstance(s, str):
+        return None
+
+    return s.strip()
+
+
+def sysctl_read(
+    path: Union[str, bytes],
+    *,
+    strip: bool = True,
+    fail_on_error: bool = False,
+) -> Optional[str]:
+
+    try:
+        with open(path, "rb") as f:
+            data = f.read()
+    except Exception:
+        if fail_on_error:
+            raise
+        return None
+
+    # We always return a `str`, but invalid characters are escaped
+    # via "surrogateescape". Depending on what you need to do, you
+    # may need to consider that.
+    s = data.decode("utf-8", errors="surrogateescape")
+    if strip:
+        s = s.strip()
+    return s
+
+
+def sysctl_phys_port_name_parse(
+    s: Optional[Union[str, bytes]]
+) -> Optional[tuple[int, int]]:
+    # Parses the output of /sys/class/net/$IFNAME/phys_port_name
+    #
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L84C6-L84C19
+
+    s = _sysctl_parse_str(s)
+    if s is None:
+        return None
+
+    m = re.search("^(c[0-9]+)?pf([0-9]+)vf([0-9]+)$", s)
+    if m:
+        try:
+            return (int(m.group(2)), int(m.group(3)))
+        except Exception:
+            pass
+
+    # old kernel syntax of phys_port_name is vf index
+    m = re.search("^[0-9]+$", s)
+    if m:
+        try:
+            return (0, int(m.group()))
+        except Exception:
+            pass
+
+    return None
+
+
+def get_phys_port_name(ifname: Union[str, bytes]) -> Optional[str]:
+    return sysctl_read(f"/sys/class/net/{validate_ifname(ifname)}/phys_port_name")
+
+
+def get_phys_switch_id(ifname: Union[str, bytes]) -> Optional[str]:
+    return sysctl_read(f"/sys/class/net/{validate_ifname(ifname)}/phys_switch_id")
+
+
+def get_ifnames() -> list[str]:
+    try:
+        ifs1 = os.listdir(b"/sys/class/net/")
+    except Exception:
+        return []
+
+    def _validate(ifname: bytes) -> Optional[str]:
+        if not os.path.islink(b"/sys/class/net/" + ifname):
+            return None
+        return validate_ifname_or_none(ifname)
+
+    return sorted(common.iter_filter_none(_validate(i) for i in ifs1))
+
+
+def get_pciaddrs() -> list[str]:
+    path = "/sys/bus/pci/devices/"
+    pcis = os.listdir(path)
+    pcis = [validate_pciaddr(p) for p in pcis if os.path.exists(path + p + "/net/")]
+    pcis2 = {k: None for k in pcis}
+    return list(pcis2)
+
+
+def _get_pciaddr_from_path(path: str) -> Optional[str]:
+    i = path.rfind("/")
+    if i >= 0:
+        pciaddr = path[i + 1 :]
+    else:
+        pciaddr = path
+    try:
+        return validate_pciaddr(pciaddr)
+    except Exception:
+        return None
+
+
+def _get_usbaddr_from_path(path: str) -> Optional[str]:
+    i = path.rfind("/")
+    if i >= 0:
+        usbaddr = path[i + 1 :]
+    else:
+        usbaddr = path
+    if not re.search("^[-0-9a-f.:]+$", usbaddr):
+        return None
+    return usbaddr
+
+
+def get_busaddr_from_ifname(ifname: Union[str, bytes]) -> Optional[tuple[str, str]]:
+    ifname = validate_ifname(ifname)
+    try:
+        path = os.readlink(f"/sys/class/net/{ifname}/device")
+    except Exception:
+        return None
+
+    pciaddr = _get_pciaddr_from_path(path)
+    if pciaddr is not None and os.path.exists(f"/sys/bus/pci/devices/{pciaddr}"):
+        return ("pci", pciaddr)
+
+    usbaddr = _get_usbaddr_from_path(path)
+    if usbaddr is not None and os.path.exists(f"/sys/bus/usb/devices/{usbaddr}"):
+        return ("usb", usbaddr)
+
+    return None
+
+
+def get_pciaddr_from_ifname(ifname: Union[str, bytes]) -> Optional[str]:
+    busaddr = get_busaddr_from_ifname(ifname)
+    if busaddr is None:
+        return None
+    bustype, busaddress = busaddr
+    if bustype != "pci":
+        return None
+    return busaddress
+
+
+def _get_ifnames_from_dir(dirname: str) -> Optional[list[str]]:
+    try:
+        devices = os.listdir(dirname)
+    except Exception:
+        return None
+    return sorted(common.iter_filter_none(validate_ifname_or_none(d) for d in devices))
+
+
+def get_ifnames_from_pciaddr(pciaddr: str) -> Optional[list[str]]:
+    return _get_ifnames_from_dir(
+        f"/sys/bus/pci/devices/{validate_pciaddr(pciaddr)}/net/"
+    )
+
+
+def get_ifindex_from_ifname(ifname: Union[str, bytes]) -> Optional[int]:
+    ifname = validate_ifname(ifname)
+    try:
+        v = sysctl_read(f"/sys/class/net/{ifname}/ifindex")
+    except Exception:
+        pass
+    else:
+        if v:
+            try:
+                return int(v)
+            except Exception:
+                pass
+    return None
+
+
+def get_address_from_ifname(ifname: Union[str, bytes]) -> Optional[str]:
+    ifname = validate_ifname(ifname)
+    try:
+        data = sysctl_read(f"/sys/class/net/{ifname}/address")
+        if data:
+            return validate_ethaddr(data)
+    except Exception:
+        pass
+    return None
+
+
+def is_switchdev(ifname: Union[str, bytes]) -> bool:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L102
+    return bool(get_phys_switch_id(ifname))
+
+
+def get_uplink_representor(pciaddr: str) -> Optional[str]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L116
+    pciaddr = validate_pciaddr(pciaddr)
+
+    devicePath = f"/sys/bus/pci/devices/{pciaddr}/physfn/net"
+    if not os.path.exists(devicePath):
+        devicePath = f"/sys/bus/pci/devices/{pciaddr}/net"
+        if not os.path.exists(devicePath):
+            return None
+
+    devices = _get_ifnames_from_dir(devicePath)
+    for device in devices or ():
+        if not is_switchdev(device):
+            continue
+        # Try to get the phys port name, if not exists then fallback to check without it
+        # phys_port_name should be in formant p<port-num> e.g p0,p1,p2 ...etc.
+        port_name = get_phys_port_name(device)
+        if port_name is not None:
+            if not re.search("^p[0-9]+$", port_name):
+                continue
+        return device
+
+    return None
+
+
+def get_vf_representor(
+    uplink_ifname: Union[str, bytes], vf_index: int
+) -> Optional[str]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L143
+    uplink_ifname = validate_ifname(uplink_ifname)
+
+    phys_switch_id = get_phys_switch_id(uplink_ifname)
+    if phys_switch_id is None:
+        return None
+
+    uplink_pciaddr = get_pciaddr_from_ifname(uplink_ifname)
+    uplink_pci_func_address = pciaddr_get_func_address(uplink_pciaddr)
+
+    devices = _get_ifnames_from_dir(f"/sys/class/net/{uplink_ifname}/subsystem")
+    for device in devices or ():
+        device_switch_id = get_phys_switch_id(device)
+        if device_switch_id != phys_switch_id:
+            continue
+        port_name = sysctl_phys_port_name_parse(get_phys_port_name(device))
+        if port_name is None:
+            continue
+        if port_name[0] != uplink_pci_func_address:
+            continue
+        if port_name[1] != vf_index:
+            continue
+
+        return device
+
+    return None
+
+
+def get_vfs_for_representor(uplink_pciaddr: str) -> list[tuple[str, int]]:
+    uplink_pciaddr = validate_pciaddr(uplink_pciaddr)
+
+    path = f"/sys/bus/pci/devices/{uplink_pciaddr}"
+
+    try:
+        files = os.listdir(path)
+    except Exception:
+        return []
+
+    result: list[tuple[str, int]] = []
+
+    regex = re.compile("^virtfn(\\d+)$")
+
+    for file in files:
+        m = regex.search(file)
+        if not m:
+            continue
+
+        try:
+            vf_index = int(m.group(1))
+        except Exception:
+            continue
+
+        try:
+            data = os.readlink(f"{path}/{file}")
+        except Exception:
+            continue
+        pciaddr = _get_pciaddr_from_path(data)
+
+        if pciaddr is None:
+            continue
+
+        result.append((pciaddr, vf_index))
+
+    return result
+
+
+@common.repeat_for_same_result
+def get_device_infos(with_ethtool: bool = True) -> list[dict[str, Any]]:
+
+    result = []
+
+    devices: set[tuple[Optional[str], Optional[str]]] = set()
+
+    link_infos: dict[str, Optional[IPRouteLinkEntry]]
+    link_infos = {ifname: None for ifname in get_ifnames()}
+    link_infos.update((lnk.ifname, lnk) for lnk in ip_links())
+
+    ifnames_tmp = set(link_infos)
+    for pciaddr1 in get_pciaddrs():
+        ifnames1 = get_ifnames_from_pciaddr(pciaddr1)
+        if ifnames1:
+            for ifname1 in ifnames1:
+                devices.add((pciaddr1, ifname1))
+                ifnames_tmp.discard(ifname1)
+        else:
+            devices.add((pciaddr1, None))
+    for ifname1 in ifnames_tmp:
+        devices.add((None, ifname1))
+
+    for device in devices:
+        res: dict[str, Any] = {}
+
+        pciaddr, ifname = device
+
+        if ifname is not None:
+            link_info = link_infos.get(ifname)
+            if link_info is not None:
+                res["ifindex"] = link_info.ifindex
+            else:
+                dict_add_optional(res, "ifindex", get_ifindex_from_ifname(ifname))
+        else:
+            link_info = None
+
+        if ifname is not None:
+            res["ifname"] = ifname
+
+        if pciaddr is not None:
+            res["pciaddr"] = pciaddr
+        elif ifname is not None:
+            busaddr = get_busaddr_from_ifname(ifname)
+            if busaddr is not None:
+                bustype, busaddress = busaddr
+                if bustype == "usb":
+                    res["usbaddr"] = busaddress
+
+        if ifname is not None:
+            link_dict: dict[str, Any] = {}
+
+            if link_info is not None:
+                li_dict = common.dataclass_to_dict(link_info)
+                del li_dict["ifindex"]
+                del li_dict["ifname"]
+            else:
+                li_dict = {}
+
+            li_address = li_dict.get("address")
+            if li_address is None:
+                li_address = get_address_from_ifname(ifname)
+
+            li_permaddr = li_dict.get("permaddr")
+            if li_permaddr is None:
+                li_permaddr = ethtool_permaddr(ifname=ifname)
+
+            dict_add_optional(link_dict, "address", li_address)
+            dict_add_optional(link_dict, "permaddr", li_permaddr)
+
+            if link_info is not None:
+                del li_dict["address"]
+                del li_dict["permaddr"]
+                if li_dict.get("link_info_kind", 1) is None:
+                    del li_dict["link_info_kind"]
+                link_dict.update(li_dict)
+
+            res["link"] = link_dict
+
+        if ifname is not None:
+            dict_add_optional(res, "phys_port_name", get_phys_port_name(ifname))
+            dict_add_optional(res, "phys_switch_id", get_phys_switch_id(ifname))
+
+        if pciaddr is not None:
+            dict_add_optional(res, "uplink_rep_ifname", get_uplink_representor(pciaddr))
+
+        if with_ethtool:
+            if ifname is not None:
+                ethdata = ethtool_driver(ifname=ifname)
+                if ethdata is not None:
+                    d3 = common.dataclass_to_dict(ethdata)
+                    del d3["ifname"]
+                    res["ethtool"] = d3
+
+        result.append(res)
+
+    uplink_reps: list[str] = sorted(
+        set(common.iter_filter_none(x1.get("uplink_rep_ifname") for x1 in result))
+    )
+
+    for uplink_rep_ifname in uplink_reps:
+        uplink_rep_pciaddr = get_pciaddr_from_ifname(uplink_rep_ifname)
+        if uplink_rep_pciaddr is None:
+            continue
+        vf_infos = get_vfs_for_representor(uplink_rep_pciaddr)
+        for vf_info in vf_infos:
+            vf_pciaddr, vf_index = vf_info
+
+            inf_vf = common.iter_get_first(
+                r for r in result if r.get("pciaddr") == vf_pciaddr
+            )
+
+            vf_rep = get_vf_representor(uplink_rep_ifname, vf_index)
+            if vf_rep is not None:
+                inf_vf_rep = common.iter_get_first(
+                    r for r in result if r.get("ifname") == vf_rep
+                )
+            else:
+                inf_vf_rep = None
+
+            d2: dict[str, Any] = {
+                "uplink_rep_ifname": uplink_rep_ifname,
+                "uplink_rep_pciaddr": uplink_rep_pciaddr,
+                "vfindex": vf_index,
+            }
+            if inf_vf is not None:
+                d3 = d2.copy()
+                if inf_vf_rep is not None:
+                    dict_add_optional(d3, "vf_rep_ifname", inf_vf_rep.get("ifname"))
+                    dict_add_optional(d3, "vf_rep_ifindex", inf_vf_rep.get("ifindex"))
+                    dict_add_optional(d3, "vf_rep_pciaddr", inf_vf_rep.get("pciaddr"))
+                inf_vf["is_vf"] = d3
+            if inf_vf_rep is not None:
+                d3 = d2.copy()
+                if inf_vf is not None:
+                    dict_add_optional(d3, "vf_ifname", inf_vf.get("ifname"))
+                    dict_add_optional(d3, "vf_ifindex", inf_vf.get("ifindex"))
+                    dict_add_optional(d3, "vf_pciaddr", inf_vf.get("pciaddr"))
+                inf_vf_rep["is_vf_rep"] = d3
+
+    result.sort(
+        key=lambda x: (
+            x.get("ifindex") or 2**33,
+            x.get("ifname") or "",
+            x.get("pciaddr") or "",
+        )
+    )
+
+    return result
+
+
+def device_infos_parse_lst(
+    device_infos_str: str,
+    *,
+    ifname: Optional[str] = None,
+    pciaddr: Optional[str] = None,
+    vf_rep_for_pciaddr: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    lst = common.json_parse_list(device_infos_str)
+    return device_infos_find(
+        lst,
+        ifname=ifname,
+        pciaddr=pciaddr,
+        vf_rep_for_pciaddr=vf_rep_for_pciaddr,
+    )
+
+
+def device_infos_find(
+    device_info_list: Iterable[Any],
+    *,
+    ifname: Optional[str] = None,
+    pciaddr: Optional[str] = None,
+    vf_rep_for_pciaddr: Optional[str] = None,
+) -> list[dict[str, Any]]:
+
+    # First, filter out all non-strdicts
+    lst = [
+        di
+        for di in device_info_list
+        if (isinstance(di, dict) and all(isinstance(k, str) for k in di))
+    ]
+
+    if ifname is not None:
+        ifname = validate_ifname(ifname)
+        lst = [di for di in lst if di.get("ifname") == ifname]
+
+    if pciaddr is not None:
+        pciaddr = validate_ifname(pciaddr)
+        lst = [di for di in lst if di.get("pciaddr") == pciaddr]
+
+    if vf_rep_for_pciaddr is not None:
+
+        vf_rep_for_pciaddr = validate_pciaddr(vf_rep_for_pciaddr)
+
+        def _match(di: dict[str, Any]) -> bool:
+            x = di.get("is_vf_rep")
+            if not isinstance(x, dict):
+                return False
+            return x.get("vf_pciaddr") == vf_rep_for_pciaddr
+
+        lst = [di for di in lst if _match(di)]
+
+    return lst
+
+
+if __name__ == "__main__":
+
+    def main() -> None:
+        import argparse
+
+        commands = {f.__name__: f for f in (get_device_infos,)}
+
+        argparser = argparse.ArgumentParser(description="Helper network functions.")
+        argparser.add_argument(
+            "command",
+            choices=commands,
+            default="get_device_infos",
+            nargs="?",
+        )
+        args = argparser.parse_args()
+
+        result = commands[args.command]()
+        print(json.dumps(result))
+
+    main()

--- a/ktoolbox/test_common.py
+++ b/ktoolbox/test_common.py
@@ -1,0 +1,508 @@
+import dataclasses
+import json
+import pytest
+import sys
+import typing
+
+from enum import Enum
+
+from . import common
+
+from .common import enum_convert
+from .common import enum_convert_list
+from .common import serialize_enum
+
+
+class TstTestType(Enum):
+    IPERF_TCP = 1
+    IPERF_UDP = 2
+    HTTP = 3
+    NETPERF_TCP_STREAM = 4
+    NETPERF_TCP_RR = 5
+
+
+class TstPodType(Enum):
+    NORMAL = 1
+    SRIOV = 2
+    HOSTBACKED = 3
+
+
+def test_str_to_bool() -> None:
+    assert common.str_to_bool(True) is True
+    assert common.str_to_bool(False) is False
+
+    ERR = object()
+    DEF = object()
+
+    # falsy
+    assert common.str_to_bool("0") is False
+    assert common.str_to_bool("n") is False
+    assert common.str_to_bool("no") is False
+    assert common.str_to_bool("false") is False
+
+    # truthy
+    assert common.str_to_bool("1") is True
+    assert common.str_to_bool("y") is True
+    assert common.str_to_bool("yes") is True
+    assert common.str_to_bool("true") is True
+
+    assert common.str_to_bool("bogus", None) is None
+    assert common.str_to_bool("default", None) is None
+    assert common.str_to_bool("bogus", ERR) is ERR
+    assert common.str_to_bool("default", ERR) is ERR
+
+    assert common.str_to_bool("bogus", ERR, on_default=DEF) is ERR
+    assert common.str_to_bool("default", ERR, on_default=DEF) is DEF
+
+    with pytest.raises(TypeError):
+        common.str_to_bool("default", ERR, on_error=DEF)  # type: ignore
+
+    with pytest.raises(ValueError):
+        assert common.str_to_bool("bogus", on_default=DEF)
+    assert common.str_to_bool("bogus", on_default=DEF, on_error=ERR) is ERR
+    assert common.str_to_bool("bogus", on_error=ERR) is ERR
+    assert common.str_to_bool("default", on_default=DEF) is DEF
+    assert common.str_to_bool("default", on_default=DEF, on_error=ERR) is DEF
+    assert common.str_to_bool("default", on_error=ERR) is ERR
+
+    # edge cases
+    with pytest.raises(ValueError):
+        common.str_to_bool(None)
+    assert common.str_to_bool(None, on_default=DEF) is DEF
+    with pytest.raises(ValueError):
+        common.str_to_bool(0, on_default=DEF)  # type: ignore
+
+    obj = object()
+
+    assert common.str_to_bool("True", on_default=False) is True
+
+    assert common.str_to_bool("", on_default=obj) is obj
+
+    with pytest.raises(ValueError):
+        common.str_to_bool("")
+
+    assert common.str_to_bool(None, on_default=obj) is obj
+    assert common.str_to_bool("", on_default=obj) is obj
+    assert common.str_to_bool(" DEFAULT ", on_default=obj) is obj
+    assert common.str_to_bool(" -1 ", on_default=obj) is obj
+
+    assert common.str_to_bool(" -1 ", on_default=DEF) is DEF
+    assert common.str_to_bool(" -1 ", on_error=ERR) is ERR
+
+    assert common.str_to_bool("", on_default=DEF, on_error=ERR) is DEF
+    assert common.str_to_bool("", on_error=ERR) is ERR
+
+    with pytest.raises(ValueError):
+        common.str_to_bool("bogus")
+
+    assert common.str_to_bool("bogus", on_error=ERR) is ERR
+    assert common.str_to_bool("bogus", on_default=DEF, on_error=obj) is obj
+
+    assert common.bool_to_str(True) == "true"
+    assert common.bool_to_str(False) == "false"
+    assert common.bool_to_str(True, format="true") == "true"
+    assert common.bool_to_str(False, format="true") == "false"
+    assert common.bool_to_str(True, format="yes") == "yes"
+    assert common.bool_to_str(False, format="yes") == "no"
+    with pytest.raises(ValueError):
+        common.bool_to_str(False, format="bogus")
+
+    if sys.version_info >= (3, 10):
+        typing.assert_type(common.str_to_bool("true"), bool)
+        typing.assert_type(common.str_to_bool("true", on_error=None), bool | None)
+        typing.assert_type(common.str_to_bool("true", on_default=None), bool | None)
+        typing.assert_type(
+            common.str_to_bool("true", on_error=None, on_default=1), bool | None | int
+        )
+        typing.assert_type(
+            common.str_to_bool("true", on_error=2, on_default=1), bool | int
+        )
+        typing.assert_type(
+            common.str_to_bool("true", on_error=True, on_default="1"), bool | str
+        )
+        typing.assert_type(
+            common.str_to_bool("true", on_error=True, on_default="1"), bool | str
+        )
+
+
+def test_enum_convert() -> None:
+    assert enum_convert(TstTestType, "IPERF_TCP") == TstTestType.IPERF_TCP
+    assert enum_convert(TstPodType, 1) == TstPodType.NORMAL
+    assert enum_convert(TstPodType, "1 ") == TstPodType.NORMAL
+    assert enum_convert(TstPodType, " normal") == TstPodType.NORMAL
+    with pytest.raises(ValueError):
+        enum_convert(TstTestType, "Not_in_enum")
+    with pytest.raises(ValueError):
+        enum_convert(TstTestType, 10000)
+
+    assert enum_convert_list(TstTestType, [1]) == [TstTestType.IPERF_TCP]
+    assert enum_convert_list(TstTestType, [TstTestType.IPERF_TCP]) == [
+        TstTestType.IPERF_TCP
+    ]
+    assert enum_convert_list(TstTestType, ["iperf-tcp"]) == [TstTestType.IPERF_TCP]
+    assert enum_convert_list(TstTestType, ["iperf_tcp-1,3", 2]) == [
+        TstTestType.IPERF_TCP,
+        TstTestType.HTTP,
+        TstTestType.IPERF_UDP,
+    ]
+
+    class E1(Enum):
+        Vm4 = -4
+        V1 = 1
+        V1b = 1
+        v2 = 2
+        V2 = 3
+        V_7 = 10
+        V_3 = 6
+        v_3 = 7
+        V5 = 5
+
+    assert enum_convert(E1, "v5") == E1.V5
+    assert enum_convert(E1, "v2") == E1.v2
+    assert enum_convert(E1, "V2") == E1.V2
+    assert enum_convert(E1, "v_3") == E1.v_3
+    assert enum_convert(E1, "V_3") == E1.V_3
+    assert enum_convert(E1, "V_7") == E1.V_7
+    assert enum_convert(E1, "V-7") == E1.V_7
+    with pytest.raises(ValueError):
+        assert enum_convert(E1, "v-3") == E1.v_3
+    with pytest.raises(ValueError):
+        assert enum_convert(E1, "V-3") == E1.V_3
+    assert enum_convert(E1, "10") == E1.V_7
+    assert enum_convert(E1, "-4") == E1.Vm4
+    assert enum_convert(E1, "1") == E1.V1
+
+
+def test_serialize_enum() -> None:
+    # Test with enum value
+    assert serialize_enum(TstTestType.IPERF_TCP) == "IPERF_TCP"
+
+    # Test with a dictionary containing enum values
+    data = {
+        "test_type": TstTestType.IPERF_UDP,
+        "pod_type": TstPodType.SRIOV,
+        "other_key": "some_value",
+    }
+    serialized_data = serialize_enum(data)
+    assert serialized_data == {
+        "test_type": "IPERF_UDP",
+        "pod_type": "SRIOV",
+        "other_key": "some_value",
+    }
+
+    # Test with a list containing enum values
+    data_list = [TstTestType.HTTP, TstPodType.HOSTBACKED]
+    serialized_list = serialize_enum(data_list)
+    assert serialized_list == ["HTTP", "HOSTBACKED"]
+
+    class TstTestCaseType(Enum):
+        POD_TO_HOST_SAME_NODE = 5
+
+    class TstConnectionMode(Enum):
+        EXTERNAL_IP = 1
+
+    class TstNodeLocation(Enum):
+        SAME_NODE = 1
+
+    # Test with nested structures
+    nested_data = {
+        "nested_dict": {"test_case_id": TstTestCaseType.POD_TO_HOST_SAME_NODE},
+        "nested_list": [TstConnectionMode.EXTERNAL_IP, TstNodeLocation.SAME_NODE],
+    }
+    serialized_nested_data = serialize_enum(nested_data)
+    assert serialized_nested_data == {
+        "nested_dict": {"test_case_id": "POD_TO_HOST_SAME_NODE"},
+        "nested_list": ["EXTERNAL_IP", "SAME_NODE"],
+    }
+
+    # Test with non-enum value
+    assert serialize_enum("some_string") == "some_string"
+    assert serialize_enum(123) == 123
+
+
+def test_strict_dataclass() -> None:
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C2:
+        a: str
+        b: int
+        c: typing.Optional[str] = None
+
+    C2("a", 5)
+    C2("a", 5, None)
+    C2("a", 5, "")
+    with pytest.raises(TypeError):
+        C2("a", "5")  # type: ignore
+    with pytest.raises(TypeError):
+        C2(3, 5)  # type: ignore
+    with pytest.raises(TypeError):
+        C2("a", 5, [])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C3:
+        a: typing.List[str]
+
+    C3([])
+    C3([""])
+    with pytest.raises(TypeError):
+        C3(1)  # type: ignore
+    with pytest.raises(TypeError):
+        C3([1])  # type: ignore
+    with pytest.raises(TypeError):
+        C3(None)  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C4:
+        a: typing.Optional[typing.List[str]]
+
+    C4(None)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C5:
+        a: typing.Optional[typing.List[typing.Dict[str, str]]] = None
+
+    C5(None)
+    C5([])
+    with pytest.raises(TypeError):
+        C5([1])  # type: ignore
+    C5([{}])
+    C5([{"a": "b"}])
+    C5([{"a": "b"}, {}])
+    C5([{"a": "b"}, {"c": "", "d": "x"}])
+    with pytest.raises(TypeError):
+        C5([{"a": None}])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C6:
+        a: typing.Optional[typing.Tuple[str, str]] = None
+
+    C6()
+    C6(None)
+    C6(("a", "b"))
+    with pytest.raises(TypeError):
+        C6(1)  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a",))  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a", "b", "c"))  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a", 1))  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass(frozen=True)
+    class TstPodInfo:
+        name: str
+        pod_type: TstPodType
+        is_tenant: bool
+        index: int
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C7:
+        addr_info: typing.List[TstPodInfo]
+
+        def _post_check(self) -> None:
+            pass
+
+    with pytest.raises(TypeError):
+        C7(None)  # type: ignore
+    C7([])
+    C7([TstPodInfo("name", TstPodType.NORMAL, True, 5)])
+    with pytest.raises(TypeError):
+        C7([TstPodInfo("name", TstPodType.NORMAL, True, 5), None])  # type:ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C8:
+        a: str
+
+        def _post_check(self) -> None:
+            if self.a == "invalid":
+                raise ValueError("_post_check() failed")
+
+    with pytest.raises(TypeError):
+        C8(None)  # type: ignore
+    C8("hi")
+    with pytest.raises(ValueError):
+        C8("invalid")
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C9:
+        a: "str"
+
+    with pytest.raises(NotImplementedError):
+        C9("foo")
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C10:
+        x: float
+
+    C10(1.0)
+    with pytest.raises(TypeError):
+        C10(1)
+
+
+def test_dataclass_tofrom_dict() -> None:
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C1:
+        foo: int
+        str: typing.Optional[str]
+
+    c1 = C1(1, "str")
+    d1 = common.dataclass_to_dict(c1)
+    assert c1 == common.dataclass_from_dict(C1, d1)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C2:
+        enum_val: TstTestType
+        c1_opt: typing.Optional[C1]
+        c1_opt_2: typing.Optional[C1]
+        c1_list: list[C1]
+
+    c2 = C2(TstTestType.IPERF_UDP, C1(2, "2"), None, [C1(3, "3"), C1(4, "4")])
+    d2 = common.dataclass_to_dict(c2)
+    assert (
+        json.dumps(d2)
+        == '{"enum_val": "IPERF_UDP", "c1_opt": {"foo": 2, "str": "2"}, "c1_opt_2": null, "c1_list": [{"foo": 3, "str": "3"}, {"foo": 4, "str": "4"}]}'
+    )
+    assert c2 == common.dataclass_from_dict(C2, d2)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C10:
+        x: float
+
+    assert common.dataclass_to_dict(C10(1.0)) == {"x": 1.0}
+
+    c10 = C10(1.0)
+    assert type(c10.x) is float
+    common.dataclass_check(c10)
+    c10.x = 1
+    assert type(c10.x) is int
+    with pytest.raises(TypeError):
+        common.dataclass_check(c10)
+    assert common.dataclass_to_dict(c10) == {"x": 1}
+
+    assert common.dataclass_from_dict(C10, {"x": 1.0}) == c10
+    assert common.dataclass_from_dict(C10, {"x": 1.0}) == C10(1.0)
+    assert common.dataclass_from_dict(C10, {"x": 1}) == c10
+    assert common.dataclass_from_dict(C10, {"x": 1}) == C10(1.0)
+    assert type(common.dataclass_from_dict(C10, {"x": 1}).x) is float
+    assert type(common.dataclass_from_dict(C10, {"x": 1.0}).x) is float
+    assert type(c10.x) is int
+    assert type(C10(1.0).x) is float
+
+
+def test_kw_only() -> None:
+    common.StructParseBaseNamed(yamlpath="yamlpath", yamlidx=0, name="name")
+    if sys.version_info >= (3, 10):
+        assert common.KW_ONLY_DATACLASS == {"kw_only": True}
+        with pytest.raises(TypeError):
+            common.StructParseBaseNamed("yamlpath", yamlidx=0, name="name")
+        with pytest.raises(TypeError):
+            common.StructParseBaseNamed("yamlpath", 0, "name")
+    else:
+        assert common.KW_ONLY_DATACLASS == {}
+        common.StructParseBaseNamed("yamlpath", yamlidx=0, name="name")
+        common.StructParseBaseNamed("yamlpath", 0, "name")
+
+
+def test_etc_hosts_update() -> None:
+    assert common.etc_hosts_update_data("", {}) == ""
+    assert common.etc_hosts_update_data("a", {}) == "a\n"
+
+    assert (
+        common.etc_hosts_update_data(
+            "",
+            {
+                "foo": ("192.168.1.3", []),
+            },
+        )
+        == "192.168.1.3 foo\n"
+    )
+    assert (
+        common.etc_hosts_update_data(
+            "10.2.3.4 foo\n",
+            {
+                "foo": ("192.168.1.3", None),
+            },
+        )
+        == "192.168.1.3 foo\n"
+    )
+    assert (
+        common.etc_hosts_update_data(
+            "  \t 10.2.3.4\tfoo foo.alias\t",
+            {
+                "foo": ("192.168.1.3", ["foo2"]),
+                "bar": ("192.168.1.1", None),
+            },
+        )
+        == "192.168.1.3 foo foo2\n\n192.168.1.1 bar\n"
+    )
+
+    assert (
+        common.etc_hosts_update_data(
+            b"  1.1.1.1 xx\xcaxx\n  \t 10.2.3.4\tfoo foo.alias\t".decode(
+                errors="surrogateescape"
+            ),
+            {
+                "foo": ("192.168.1.3", ["foo2"]),
+                "bar": ("192.168.1.1", None),
+            },
+        ).encode(errors="surrogateescape")
+        == b"  1.1.1.1 xx\xcaxx\n192.168.1.3 foo foo2\n\n192.168.1.1 bar\n"
+    )
+
+    assert (
+        common.etc_hosts_update_data(
+            """127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.131.100.100 marvell-dpu-42 dpu
+""",
+            {
+                "marvell-dpu-42": ("172.131.100.100", ["dpu"]),
+            },
+        )
+        == """127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.131.100.100 marvell-dpu-42 dpu
+"""
+    )
+
+    assert (
+        common.etc_hosts_update_data(
+            """127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.131.100.100 marvell-dpu-42 dpu
+""",
+            {
+                "marvell-dpu-42": ("172.131.100.100", ["dpu2"]),
+            },
+        )
+        == """127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.131.100.100 marvell-dpu-42 dpu2
+"""
+    )
+
+
+def test_serial() -> None:
+    try:
+        import serial
+    except ModuleNotFoundError:
+        pytest.skip("pyserial module not available")
+
+    with pytest.raises(serial.serialutil.SerialException):
+        common.Serial("")

--- a/ktoolbox/test_firewall.py
+++ b/ktoolbox/test_firewall.py
@@ -1,0 +1,28 @@
+from . import firewall
+
+
+def test_nft_cmd_masquerade() -> None:
+    assert (
+        firewall.nft_data_masquerade_down(table_name="foo")
+        == """add table ip foo
+delete table ip foo
+"""
+    )
+    assert (
+        firewall.nft_data_masquerade_up(
+            table_name="foo",
+            subnet="191.168.5.0/24",
+            ifname="eno4",
+        )
+        == """add table ip foo
+flush table ip foo
+add chain ip foo nat_postrouting { type nat hook postrouting priority 100; policy accept; };
+add rule ip foo nat_postrouting ip saddr 191.168.5.0/24 ip daddr != 191.168.5.0/24 masquerade;
+add chain ip foo filter_forward { type filter hook forward priority 0; policy accept; };
+add rule ip foo filter_forward ip daddr 191.168.5.0/24 oifname "eno4"  ct state { established, related } accept;
+add rule ip foo filter_forward ip saddr 191.168.5.0/24 iifname "eno4" accept;
+add rule ip foo filter_forward iifname "eno4" oifname "eno4" accept;
+add rule ip foo filter_forward iifname "eno4" reject;
+add rule ip foo filter_forward oifname "eno4" reject;
+"""
+    )

--- a/ktoolbox/test_host.py
+++ b/ktoolbox/test_host.py
@@ -1,0 +1,214 @@
+import functools
+import os
+import pathlib
+import pytest
+import sys
+
+from . import host
+
+
+@functools.cache
+def has_sudo(rsh: host.Host) -> bool:
+    r = rsh.run("sudo -n whoami")
+    return r == host.Result("root\n", "", 0)
+
+
+def skip_without_sudo(rsh: host.Host) -> None:
+    if not has_sudo(rsh):
+        pytest.skip(
+            "sudo on {rsh.pretty_str()} does not seem to work passwordless ({r})"
+        )
+
+
+def test_host_result_bin() -> None:
+    res = host.local.run("echo -n out; echo -n err >&2", text=False)
+    assert res == host.BinResult(b"out", b"err", 0)
+
+
+def test_host_result_surrogateescape() -> None:
+    res = host.local.run("echo -n hi", decode_errors="surrogateescape")
+    assert res == host.Result("hi", "", 0)
+
+    cmd = ["bash", "-c", "printf $'xx<\\325>'"]
+
+    res_bin = host.local.run(cmd, text=False)
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+    res = host.local.run(cmd, decode_errors="surrogateescape")
+    assert res == host.Result("xx<\udcd5>", "", 0)
+    with pytest.raises(UnicodeEncodeError):
+        res.out.encode()
+    assert res.out.encode(errors="surrogateescape") == b"xx<\325>"
+
+    res_bin = host.local.run(["bash", "-c", 'printf "xx<\udcd5>"'], text=False)
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+    res_bin = host.local.run(["echo", "-n", "xx<\udcd5>"], text=False)
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+    cmd2 = b'echo -n "xx<\325>"'.decode(errors="surrogateescape")
+    res_bin = host.local.run(cmd2, text=False)
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+    t = False
+    res_any = host.local.run(cmd2, text=t)
+    assert isinstance(res_any, host.BinResult)
+    assert res_any == host.BinResult(b"xx<\325>", b"", 0)
+
+    res = host.local.run(cmd2)
+    assert res == host.Result("xx<�>", "", 0)
+
+    res = host.local.run(cmd2, decode_errors="surrogateescape")
+    assert res == host.Result("xx<\udcd5>", "", 0)
+
+    res_bin = host.local.run(["bash", "-c", cmd2], text=False)
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+
+def test_host_result_str() -> None:
+    res = host.local.run("echo -n out; echo -n err >&2", text=True)
+    assert res == host.Result("out", "err", 0)
+
+    res = host.local.run("echo -n out; echo -n err >&2")
+    assert res == host.Result("out", "err", 0)
+
+
+def test_host_various_results() -> None:
+    res = host.local.run('printf "foo:\\705x"')
+    assert res == host.Result("foo:\ufffdx", "", 0)
+
+    # The result with decode_errors="replace" is the same as if decode_errors
+    # is left unspecified. However, the latter case will log an ERROR message
+    # when seeing unexpected binary. If you set decode_errors, you expect
+    # binary, and no error message is logged.
+    res = host.local.run('printf "foo:\\705x"', decode_errors="replace")
+    assert res == host.Result("foo:\ufffdx", "", 0)
+
+    res = host.local.run('printf "foo:\\705x"', decode_errors="ignore")
+    assert res == host.Result("foo:x", "", 0)
+
+    with pytest.raises(UnicodeDecodeError):
+        res = host.local.run('printf "foo:\\705x"', decode_errors="strict")
+
+    res = host.local.run('printf "foo:\\705x"', decode_errors="backslashreplace")
+    assert res == host.Result("foo:\\xc5x", "", 0)
+
+    binres = host.local.run('printf "foo:\\705x"', text=False)
+    assert binres == host.BinResult(b"foo:\xc5x", b"", 0)
+
+
+def test_host_check_success() -> None:
+
+    res = host.local.run("echo -n foo", check_success=lambda r: r.success)
+    assert res == host.Result("foo", "", 0)
+    assert res.success
+
+    res = host.local.run("echo -n foo", check_success=lambda r: r.out != "foo")
+    assert res == host.Result("foo", "", 0, forced_success=False)
+    assert not res.success
+
+    binres = host.local.run(
+        "echo -n foo", text=False, check_success=lambda r: r.out != b"foo"
+    )
+    assert binres == host.BinResult(b"foo", b"", 0, forced_success=False)
+    assert not binres.success
+
+    res = host.local.run("echo -n foo; exit 74", check_success=lambda r: r.success)
+    assert res == host.Result("foo", "", 74)
+    assert not res.success
+
+    res = host.local.run("echo -n foo; exit 74", check_success=lambda r: r.out == "foo")
+    assert res == host.Result("foo", "", 74, forced_success=True)
+    assert res.success
+
+    binres = host.local.run(
+        "echo -n foo; exit 74", text=False, check_success=lambda r: r.out == b"foo"
+    )
+    assert binres == host.BinResult(b"foo", b"", 74, forced_success=True)
+    assert binres.success
+
+
+def test_host_file_exists() -> None:
+    assert host.local.file_exists(__file__)
+    assert host.Host.file_exists(host.local, __file__)
+    assert host.local.file_exists(os.path.dirname(__file__))
+    assert host.Host.file_exists(host.local, os.path.dirname(__file__))
+
+    assert host.local.file_exists(pathlib.Path(__file__))
+    assert host.Host.file_exists(host.local, pathlib.Path(__file__))
+
+
+def test_result_typing() -> None:
+    host.Result("out", "err", 0)
+    host.Result("out", "err", 0, forced_success=True)
+    host.BinResult(b"out", b"err", 0)
+    host.BinResult(b"out", b"err", 0, forced_success=True)
+
+    if sys.version_info >= (3, 10):
+        with pytest.raises(TypeError):
+            host.Result("out", "err", 0, True)
+        with pytest.raises(TypeError):
+            host.BinResult(b"out", b"err", 0, True)
+    else:
+        host.Result("out", "err", 0, True)
+        host.BinResult(b"out", b"err", 0, True)
+
+
+def test_cwd() -> None:
+    res = host.local.run("pwd", cwd="/usr/bin")
+    assert res == host.Result("/usr/bin\n", "", 0)
+
+    res = host.local.run(["pwd"], cwd="/usr/bin")
+    assert res == host.Result("/usr/bin\n", "", 0)
+
+    res = host.local.run("pwd", cwd="/usr/bin/does/not/exist")
+    assert res.out == ""
+    assert res.returncode == 1
+    assert "/usr/bin/does/not/exist" in res.err
+
+    res = host.local.run("pwd", cwd="/root")
+    if res == host.Result("/root\n", "", 0):
+        # We have permissions to access the directory.
+        pass
+    else:
+        assert res.out == ""
+        assert res.returncode == 1
+        assert "/root" in res.err
+
+
+def test_sudo() -> None:
+    skip_without_sudo(host.local)
+
+    rsh = host.LocalHost(sudo=True)
+
+    assert rsh.run("whoami") == host.Result("root\n", "", 0)
+
+    assert rsh.run(["whoami"]) == host.Result("root\n", "", 0)
+
+    res = rsh.run('echo ">>$FOO<"', env={"FOO": "xx1"})
+    assert res == host.Result(">>xx1<\n", "", 0)
+
+    res = rsh.run(
+        ["bash", "-c", 'echo ">>$FOO2<" >&2; exit 55'], env={"FOO2": "xx1", "F1": None}
+    )
+    assert res == host.Result("", ">>xx1<\n", 55)
+
+    res = rsh.run("pwd", cwd="/usr/bin")
+    assert res == host.Result("/usr/bin\n", "", 0)
+
+    res = rsh.run(["pwd"], cwd="/usr/bin")
+    assert res == host.Result("/usr/bin\n", "", 0)
+
+    res = rsh.run("echo hi; whoami >&2; pwd", cwd="/usr/bin")
+    assert res == host.Result("hi\n/usr/bin\n", "root\n", 0)
+
+    res = rsh.run(["bash", "-c", "echo hi; whoami >&2; pwd"], cwd="/usr/bin")
+    assert res == host.Result("hi\n/usr/bin\n", "root\n", 0)
+
+    res = rsh.run("pwd", cwd="/usr/bin/does/not/exist")
+    assert res.out == ""
+    assert res.returncode == 1
+    assert "/usr/bin/does/not/exist" in res.err
+
+    res = rsh.run("pwd", cwd="/root")
+    assert res == host.Result("/root\n", "", 0)

--- a/ktoolbox/test_netdev.py
+++ b/ktoolbox/test_netdev.py
@@ -1,0 +1,107 @@
+import functools
+import pytest
+
+from . import host
+from . import netdev
+
+
+@functools.cache
+def has_ip_route() -> bool:
+    return host.local.run("ip addr").returncode != 127
+
+
+def skip_without_ip_route() -> None:
+    if not has_ip_route():
+        pytest.skip("has no iproute2")
+
+
+def test_ip_addrs() -> None:
+    # We expect to have at least one address configured on the system and that
+    # `ip -json addr` works. The unit test requires that.
+    if not has_ip_route():
+        assert netdev.ip_addrs(host.local) == []
+    skip_without_ip_route()
+
+    assert netdev.ip_addrs(host.local)
+
+
+def test_ip_links() -> None:
+    if not has_ip_route():
+        assert netdev.ip_links(host.local) == []
+    skip_without_ip_route()
+
+    links = netdev.ip_links(host.local)
+    assert links
+    assert [link.ifindex for link in links if link.ifname == "lo"] == [1]
+
+    assert [link.ifindex for link in netdev.ip_links(host.local, ifname="lo")] == [1]
+
+    ifnames = netdev.get_ifnames()
+    for ifname in ifnames:
+        ipl = netdev.ip_links(ifname=ifname)
+        assert isinstance(ipl, list)
+        assert len(ipl) == 1
+        assert ipl[0].ifname == ifname
+
+
+def test_ip_routes() -> None:
+    # We expect to have at least one route configured on the system and that
+    # `ip -json route` works. The unit test requires that.
+    if not has_ip_route():
+        assert netdev.ip_routes(host.local) == []
+    skip_without_ip_route()
+
+    assert netdev.ip_routes(host.local)
+
+
+def test_sysctl_phys_port_name_parse() -> None:
+    assert netdev.sysctl_phys_port_name_parse("") is None
+    assert netdev.sysctl_phys_port_name_parse("  555\n") == (0, 555)
+    assert netdev.sysctl_phys_port_name_parse("  c1pf6vf55\n") == (6, 55)
+
+
+def test_validate_pciaddr() -> None:
+    assert netdev.validate_pciaddr(b"0000:ff:0a.7") == "0000:ff:0a.7"
+    assert netdev.validate_pciaddr("0000:ff:0a.7") == "0000:ff:0a.7"
+    with pytest.raises(Exception):
+        netdev.validate_pciaddr(b"0000:ff:0a.7/")
+    with pytest.raises(Exception):
+        netdev.validate_pciaddr("0000:ff:0A.7")
+
+
+def test_ifnames_and_pciaddrs() -> None:
+    ifnames = netdev.get_ifnames()
+    assert isinstance(ifnames, list)
+    assert all(isinstance(i, str) for i in ifnames)
+    assert "lo" in ifnames
+
+    pciaddrs = netdev.get_pciaddrs()
+    assert isinstance(pciaddrs, list)
+    assert all(isinstance(i, str) for i in pciaddrs)
+
+    ifname_to_pci: dict[str, str] = {}
+    pci_to_ifname: dict[str, str] = {}
+
+    for ifname1 in ifnames:
+        pciaddr = netdev.get_pciaddr_from_ifname(ifname1)
+        if pciaddr is not None:
+            assert pciaddr in pciaddrs
+            assert ifname1 in (netdev.get_ifnames_from_pciaddr(pciaddr) or ())
+            ifname_to_pci[ifname1] = pciaddr
+
+    for pci in pciaddrs:
+        ifnames2 = netdev.get_ifnames_from_pciaddr(pci)
+        if ifnames2 is not None:
+            for ifname2 in ifnames2:
+                assert ifname2 in ifnames
+                assert netdev.get_pciaddr_from_ifname(ifname2) == pci
+                pci_to_ifname[pci] = ifname2
+
+    assert {v: k for k, v in pci_to_ifname.items()} == ifname_to_pci
+    assert {v: k for k, v in ifname_to_pci.items()} == pci_to_ifname
+
+
+def test_get_device_infos() -> None:
+    result = netdev.get_device_infos()
+    assert isinstance(result, list)
+    assert "lo" in [x.get("ifname") for x in result]

--- a/manifests/pxeboot/grub.cfg
+++ b/manifests/pxeboot/grub.cfg
@@ -1,6 +1,6 @@
 set timeout=10
 
 menuentry 'Install' {
-    linux pxelinux/vmlinuz ip=dhcp inst.repo=http://172.131.100.1/marvel_dpu_iso/ inst.ks=http://172.131.100.1/kickstart.ks
+    linux pxelinux/vmlinuz ip=dhcp inst.repo=http://172.131.100.1:24380/marvel_dpu_iso/ inst.ks=http://172.131.100.1:24380/kickstart.ks
     initrd pxelinux/initrd.img
 }

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -159,4 +159,9 @@ EOF
 
 fi
 
+################################################################################
+
+# Allow password login as root.
+sed -i 's/.*PermitRootLogin.*/# \0\nPermitRootLogin yes/' /etc/ssh/sshd_config
+
 %end

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -70,4 +70,47 @@ if [ -n "$SSH_PUBKEY" ] ; then
     printf '%s\n' "$SSH_PUBKEY" >> /root/.ssh/authorized_keys
 fi
 
+################################################################################
+
+cat <<EOF > /etc/NetworkManager/system-connections/enP2p2s0-dpu-secondary.nmconnection
+[connection]
+id=enP2p2s0-dpu-secondary
+uuid=$(uuidgen)
+type=ethernet
+autoconnect-priority=20
+interface-name=enP2p2s0
+
+[ipv4]
+method=auto
+dhcp-timeout=2147483647
+route-metric=110
+
+[ipv6]
+method=auto
+addr-gen-mode=eui64
+route-metric=110
+EOF
+chmod 600 /etc/NetworkManager/system-connections/enP2p2s0-dpu-secondary.nmconnection
+
+cat <<EOF > /etc/NetworkManager/system-connections/enP2p3s0-dpu-host.nmconnection
+[connection]
+id=enP2p3s0-dpu-host
+uuid=$(uuidgen)
+type=ethernet
+autoconnect-priority=10
+interface-name=enP2p3s0
+
+[ipv4]
+method=auto
+address1=@__DPU_IP4ADDRNET__@,@__HOST_IP4ADDR__@
+dhcp-timeout=2147483647
+route-metric=120
+
+[ipv6]
+method=auto
+addr-gen-mode=eui64
+route-metric=120
+EOF
+chmod 600 /etc/NetworkManager/system-connections/enP2p3s0-dpu-host.nmconnection
+
 %end

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -52,6 +52,7 @@ git
 grubby
 xterm
 NetworkManager-config-server
+podman
 %end
 
 ################################################################################

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -88,6 +88,7 @@ cloned-mac-address=@__NM_SECONDARY_CLONED_MAC_ADDRESS__@
 method=auto
 dhcp-timeout=2147483647
 route-metric=110
+@__NM_SECONDARY_IP_ADDRESS__@
 
 [ipv6]
 method=auto

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -22,7 +22,7 @@ skipx
 firstboot --disabled
 
 # Network information
-network --bootproto=dhcp --hostname=marvell-dpu.redhat --device=enP2p6s0 --activate
+network --bootproto=dhcp --hostname=@__FQDNNAME__@ --device=enP2p6s0 --activate
 
 ignoredisk --only-use=nvme0n1
 # System bootloader configuration

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -53,3 +53,21 @@ grubby
 xterm
 NetworkManager-config-server
 %end
+
+################################################################################
+#
+################################################################################
+
+%post --log=/var/log/kickstart_post.log
+
+set -x
+
+SSH_PUBKEY=@__SSH_PUBKEY__@
+if [ -n "$SSH_PUBKEY" ] ; then
+    mkdir -p /root/.ssh
+    touch /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+    printf '%s\n' "$SSH_PUBKEY" >> /root/.ssh/authorized_keys
+fi
+
+%end

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -80,6 +80,9 @@ type=ethernet
 autoconnect-priority=20
 interface-name=enP2p2s0
 
+[ethernet]
+cloned-mac-address=@__NM_SECONDARY_CLONED_MAC_ADDRESS__@
+
 [ipv4]
 method=auto
 dhcp-timeout=2147483647

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -113,4 +113,12 @@ route-metric=120
 EOF
 chmod 600 /etc/NetworkManager/system-connections/enP2p3s0-dpu-host.nmconnection
 
+################################################################################
+
+cat <<EOF >> /etc/chrony.conf
+
+# Appended by marvell-tools
+@__CHRONY_SERVERS__@
+EOF
+
 %end

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,4 @@
 [mypy]
 
-[mypy-pexpect]
+[mypy-serial]
 ignore_missing_imports = True

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -291,7 +291,7 @@ def setup_http(
 
     def http_server() -> None:
         os.chdir("/www")
-        server_address = ("", 80)
+        server_address = (common_dpu.host_ip4addr, 80)
         handler = http.server.SimpleHTTPRequestHandler
         httpd = http.server.HTTPServer(server_address, handler)
         httpd.serve_forever()

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -261,6 +261,9 @@ def prepare_host(dev: str, host_path: str, ssh_key: Optional[list[str]]) -> list
         ip4addr=common_dpu.host_ip4addrnet,
     )
 
+    common_dpu.nft_masquerade(ifname=dev, subnet=common_dpu.dpu_subnet)
+    host.local.run("sysctl -w net.ipv4.ip_forward=1")
+
     ssh_pubkey = []
 
     add_host_key = True

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -182,6 +182,8 @@ def copy_kickstart(ssh_pubkey: list[str]) -> None:
     kickstart = kickstart.replace(
         "@__SSH_PUBKEY__@", shlex.quote("\n".join(ssh_pubkey))
     )
+    kickstart = kickstart.replace("@__DPU_IP4ADDRNET__@", common_dpu.dpu_ip4addrnet)
+    kickstart = kickstart.replace("@__HOST_IP4ADDR__@", common_dpu.host_ip4addr)
 
     with open("/www/kickstart.ks", "w") as f:
         f.write(kickstart)

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -6,7 +6,6 @@ import os
 import pexpect
 import shlex
 import shutil
-import signal
 import time
 
 from collections.abc import Iterable
@@ -322,26 +321,8 @@ def try_pxeboot(args: argparse.Namespace) -> None:
     print("SUCCESS. Try `ssh root@dpu`")
 
 
-def kill_existing() -> None:
-    pids = [pid for pid in os.listdir("/proc") if pid.isdigit()]
-
-    own_pid = os.getpid()
-    for pid in filter(lambda x: int(x) != own_pid, pids):
-        try:
-            with open(os.path.join("/proc", pid, "cmdline"), "rb") as f:
-                # print(f.read().decode("utf-8"))
-                zb = b"\x00"
-                cmd = [x.decode("utf-8") for x in f.read().strip(zb).split(zb)]
-                if "python" in cmd[0] and os.path.basename(cmd[1]) == "pxeboot.py":
-                    print(f"Killing pid {pid}")
-                    os.kill(int(pid), signal.SIGKILL)
-        except Exception:
-            pass
-
-
 def main() -> None:
     args = parse_args()
-    kill_existing()
     try_pxeboot(args)
 
 

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -61,10 +61,9 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def run_process(cmd: str) -> Process:
-    p = Process(target=run, args=(cmd,))
-    p.start()
-    return p
+def ping(hn: str) -> bool:
+    ping_cmd = f"timeout 1 ping -4 -c 1 {hn}"
+    return run(ping_cmd).returncode == 0
 
 
 def wait_any_ping(hn: Iterable[str], timeout: float) -> str:
@@ -79,11 +78,6 @@ def wait_any_ping(hn: Iterable[str], timeout: float) -> str:
         time.sleep(5)
         end = time.time()
     raise Exception(f"No response after {round(end - begin, 2)}s")
-
-
-def ping(hn: str) -> bool:
-    ping_cmd = f"timeout 1 ping -4 -c 1 {hn}"
-    return run(ping_cmd).returncode == 0
 
 
 def wait_for_boot() -> None:
@@ -177,23 +171,6 @@ def post_pxeboot(host_path: str) -> None:
     write_hosts_entry(host_path)
 
 
-def uefi_pxe_boot(args: argparse.Namespace) -> None:
-    print("Starting UEFI PXE Boot")
-    print("Resetting card")
-    reset()
-    select_pxe_entry()
-    wait_for_boot()
-    post_pxeboot(args.host_path)
-
-
-def http_server() -> None:
-    os.chdir("/www")
-    server_address = ("", 80)
-    handler = http.server.SimpleHTTPRequestHandler
-    httpd = http.server.HTTPServer(server_address, handler)
-    httpd.serve_forever()
-
-
 def copy_kickstart(host_path: str, ssh_pubkey: list[str], yum_repos: str) -> None:
     with open(common_dpu.packaged_file("manifests/pxeboot/kickstart.ks"), "r") as f:
         kickstart = f.read()
@@ -227,6 +204,13 @@ def setup_http(host_path: str, ssh_pubkey: list[str], yum_repos: str) -> None:
 
     copy_kickstart(host_path, ssh_pubkey, yum_repos)
 
+    def http_server() -> None:
+        os.chdir("/www")
+        server_address = ("", 80)
+        handler = http.server.SimpleHTTPRequestHandler
+        httpd = http.server.HTTPServer(server_address, handler)
+        httpd.serve_forever()
+
     p = Process(target=http_server)
     p.start()
     children.append(p)
@@ -237,7 +221,7 @@ def setup_tftp() -> None:
     os.makedirs("/var/lib/tftpboot/pxelinux", exist_ok=True)
     print("starting in.tftpd")
     run("killall in.tftpd")
-    p = run_process("/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
+    p = common_dpu.run_process("/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
     children.append(p)
     shutil.copy(
         f"{iso_mount_path}/images/pxeboot/vmlinuz", "/var/lib/tftpboot/pxelinux"
@@ -288,7 +272,7 @@ def setup_dhcp() -> None:
         common_dpu.packaged_file("manifests/pxeboot/dhcpd.conf"), "/etc/dhcp/dhcpd.conf"
     )
     run("killall dhcpd")
-    p = run_process(
+    p = common_dpu.run_process(
         "/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd"
     )
     children.append(p)
@@ -300,30 +284,27 @@ def mount_iso(iso_path: str) -> None:
     run(f"mount -t iso9660 -o loop {iso_path} {iso_mount_path}")
 
 
-def prepare_pxeboot(args: argparse.Namespace) -> None:
+def main() -> None:
+    args = parse_args()
+    print("Preparing services for Pxeboot")
     ssh_pubkey = prepare_host(args.dev, args.host_path, args.ssh_key)
     iso_path = common_dpu.create_iso_file(args.iso, chroot_path=args.host_path)
     setup_dhcp()
     mount_iso(iso_path)
     setup_tftp()
     setup_http(args.host_path, ssh_pubkey, args.yum_repos)
-
-
-def try_pxeboot(args: argparse.Namespace) -> None:
-    print("Preparing services for Pxeboot")
-    prepare_pxeboot(args)
     print("Giving services time to settle")
     time.sleep(10)
-    uefi_pxe_boot(args)
+    print("Starting UEFI PXE Boot")
+    print("Resetting card")
+    reset()
+    select_pxe_entry()
+    wait_for_boot()
+    post_pxeboot(args.host_path)
     print("Terminating http, tftp, and dhcpd")
     for e in children:
         e.terminate()
     print("SUCCESS. Try `ssh root@dpu`")
-
-
-def main() -> None:
-    args = parse_args()
-    try_pxeboot(args)
 
 
 if __name__ == "__main__":

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import argparse
 import http.server
 import os

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -30,7 +30,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "iso",
         type=str,
-        help="Mandatory argument of type string for ISO file (make sure the path to this file was mounted when running the pod via -v /host/iso:/container/iso).",
+        nargs="?",
+        default="rhel:9.4",
+        help='Select the RHEL ISO to install. This can be a file name (make sure to map the host with `-v /:/host` and specify the path name starting with "/host"); it can be a HTTP URL (in which case the file will be downloaded to /host/root/rhel-iso-$NAME if such file does not exist yet); it can also be "rhel:9.x" which will automatically detect the right HTTP URL to download the latest iso. Default: "rhel:" to choose a recent RHEL version',
     )
     parser.add_argument(
         "--dev",
@@ -56,12 +58,7 @@ def parse_args() -> argparse.Namespace:
         help='We generate "/etc/yum.repos.d/marvell-tools-beaker.repo" with latest RHEL9 nightly compose. However, that repo is disabled unless "--yum-repos=rhel-nightly".',
     )
 
-    args = parser.parse_args()
-    if not os.path.exists(args.iso):
-        print(f"Couldn't read iso file {args.iso}")
-        raise Exception("Invalid path to iso provided")
-
-    return args
+    return parser.parse_args()
 
 
 def run_process(cmd: str) -> Process:
@@ -280,16 +277,17 @@ def setup_dhcp() -> None:
     children.append(p)
 
 
-def mount_iso(iso: str) -> None:
+def mount_iso(iso_path: str) -> None:
     os.makedirs(iso_mount_path, exist_ok=True)
     run(f"umount {iso_mount_path}")
-    run(f"mount -t iso9660 -o loop {iso} {iso_mount_path}")
+    run(f"mount -t iso9660 -o loop {iso_path} {iso_mount_path}")
 
 
 def prepare_pxeboot(args: argparse.Namespace) -> None:
     ssh_pubkey = prepare_host(args.dev, args.host_path, args.ssh_key)
+    iso_path = common_dpu.create_iso_file(args.iso, chroot_path=args.host_path)
     setup_dhcp()
-    mount_iso(args.iso)
+    mount_iso(iso_path)
     setup_tftp()
     setup_http(args.host_path, ssh_pubkey, args.yum_repos)
 

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -17,7 +17,11 @@ from ktoolbox import host
 
 import common_dpu
 
-from common_dpu import run, minicom_cmd
+from common_dpu import ESC
+from common_dpu import KEY_DOWN
+from common_dpu import KEY_ENTER
+from common_dpu import minicom_cmd
+from common_dpu import run
 from reset import reset
 
 
@@ -93,9 +97,6 @@ def wait_for_boot() -> None:
 
 def select_pxe_entry() -> None:
     print("selecting pxe entry")
-    ESC = "\x1b"
-    KEY_DOWN = "\x1b[B"
-    KEY_ENTER = "\r\n"
 
     run("pkill -9 minicom")
     print("spawn minicom")

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -291,7 +291,7 @@ def setup_http(
 
     def http_server() -> None:
         os.chdir("/www")
-        server_address = (common_dpu.host_ip4addr, 80)
+        server_address = (common_dpu.host_ip4addr, 24380)
         handler = http.server.SimpleHTTPRequestHandler
         httpd = http.server.HTTPServer(server_address, handler)
         httpd.serve_forever()

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -78,6 +78,12 @@ def parse_args() -> argparse.Namespace:
         default="marvell-dpu",
         help='The static hostname of the DPU. Defaults to "marvell-dpu". With "--host-mode=rhel" this is also added to /etc/hosts alongside "dpu".',
     )
+    parser.add_argument(
+        "--nm-secondary-cloned-mac-address",
+        type=str,
+        default="",
+        help='The MAC address to configure on the "enP2p2s0-dpu-secondary" profile.',
+    )
 
     return parser.parse_args()
 
@@ -207,7 +213,11 @@ def post_pxeboot(host_mode: str, host_path: str, dpu_name: str) -> None:
 
 
 def copy_kickstart(
-    host_path: str, dpu_name: str, ssh_pubkey: list[str], yum_repos: str
+    host_path: str,
+    dpu_name: str,
+    ssh_pubkey: list[str],
+    yum_repos: str,
+    nm_secondary_cloned_mac_address: str,
 ) -> None:
     with open(common_dpu.packaged_file("manifests/pxeboot/kickstart.ks"), "r") as f:
         kickstart = f.read()
@@ -218,6 +228,10 @@ def copy_kickstart(
     )
     kickstart = kickstart.replace("@__DPU_IP4ADDRNET__@", common_dpu.dpu_ip4addrnet)
     kickstart = kickstart.replace("@__HOST_IP4ADDR__@", common_dpu.host_ip4addr)
+    kickstart = kickstart.replace(
+        "@__NM_SECONDARY_CLONED_MAC_ADDRESS__@",
+        nm_secondary_cloned_mac_address,
+    )
     kickstart = kickstart.replace("@__YUM_REPOS__@", shlex.quote(yum_repos))
 
     res = host.local.run(
@@ -237,12 +251,18 @@ def copy_kickstart(
 
 
 def setup_http(
-    host_path: str, dpu_name: str, ssh_pubkey: list[str], yum_repos: str
+    host_path: str,
+    dpu_name: str,
+    ssh_pubkey: list[str],
+    yum_repos: str,
+    nm_secondary_cloned_mac_address: str,
 ) -> None:
     os.makedirs("/www", exist_ok=True)
     run(f"ln -s {iso_mount_path} /www")
 
-    copy_kickstart(host_path, dpu_name, ssh_pubkey, yum_repos)
+    copy_kickstart(
+        host_path, dpu_name, ssh_pubkey, yum_repos, nm_secondary_cloned_mac_address
+    )
 
     def http_server() -> None:
         os.chdir("/www")
@@ -348,7 +368,13 @@ def main() -> None:
         setup_dhcp()
         mount_iso(iso_path)
         setup_tftp()
-        setup_http(args.host_path, args.dpu_name, ssh_pubkey, args.yum_repos)
+        setup_http(
+            args.host_path,
+            args.dpu_name,
+            ssh_pubkey,
+            args.yum_repos,
+            args.nm_secondary_cloned_mac_address,
+        )
         print("Giving services time to settle")
         time.sleep(10)
         print("Starting UEFI PXE Boot")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 PyYAML==6.0.1
-pexpect
+pyserial

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+PyYAML==6.0.1
 pexpect

--- a/reset.py
+++ b/reset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import pexpect
 import time
 

--- a/reset.py
+++ b/reset.py
@@ -3,13 +3,9 @@
 import pexpect
 import time
 
+from common_dpu import KEY_ENTER
 from common_dpu import minicom_cmd
 from common_dpu import run
-
-
-ESC = "\x1b"
-KEY_DOWN = "\x1b[B"
-KEY_ENTER = "\r\n"
 
 
 def reset() -> None:


### PR DESCRIPTION
Overall, pxeboot still does the same as before (and it works nicely). This branch makes some improvements by installing some useful things.

Usage:
```
IMAGE=quay.io/sdaniele/marvell-tools:latest
sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -w /marvell-octeon-10-tools -ti "$IMAGE" python ./pxeboot.py --help
```

This will be called from cluster-deployment-automation during deploy. But you can also call it manually. It must run on the host that has the DPU plugged in. The DPU must be on `/dev/ttyUSB0` and its management interface connected to the hosts `eno4` (see also the `pxeboot.py --dev` option). Especially for CDA, we expect that the secondary interface is switched together with an interface on the provisioning host. For cluster deployment, that is the way how CDA will reach the DPU. The DPU will run DHCP on that interface.

To run the podman command, you obviously must be able to SSH into the host (or `oc debug node/$HOST`) to run `podman-run`.

Minor points:

- add an option `--host-mode=auto|rhel|coreos`. Even though most of the things are encapsulated in the podman container, when pxeboot runs, it still needs to configure the host a bit (at least add the IP address 172.131.100.1 and setup nft-masquerading). On RHEL that makes sense, and in in that case, some persistent configuration is done (e.g. a NetworkManager connection profile for the IP address). If the host is a OCP worker node and runs CoreOS, such persistent configuration makes no sense. The host-mode determines what is done on the host.

- With `--host-mode=rhel`, on the host, create a persistent NetworkManager profile `eno4-marvell-dpu`. That is useful on a RHEL host that we want to keep around. On CoreOS, just use `ip addr add 172.131.100.1/24 dev eno4`.

- on the DPU, create two NetworkManager profiles `enP2p3s0-dpu-host` and `enP2p2s0-dpu-secondary`. Both do DHCP+SLAAC.  `enP2p3s0-dpu-host`  is expected to be connected to `eno4` on the host ( `eno4-marvell-dpu` with 172.131.100.1 address). It also has a static IP address 172.131.100.100. You will always be able to SSH into the DPU by configuring a  172.131.100.1/24 on `eno4` and `ssh root@172.131.100.100`.

- configure static chrony NTP servers in the DPU. That is useful, if no DHCP server is running. It's important that the time is not widely off, and the public NTP servers may not be reachable.

- copy a SSH public key to the DPU's `/root/.ssh/authorized_keys`. See `--ssh-key` argument. `--ssh-key=none` disables this. Otherwise, it takes the host's `/root/.ssh/id_ed25519.pub` or (in `--host-mode=rhel`) generates such a key. With this, you can SSH into the root user  DPU.

- configure nft masquerading rules on the host and set `net.ipv4.ip_forward`. This configuration is ephemeral, and will be lost if the host reboots. You can restore that host configuration with the `pxeboot.py --host-only` option.

- add yum.repos.d repositories inside the DPU to latest nightlies.

- in `--host-mode=rhel` add entry `172.131.100.100 dpu` to `/etc/hosts`. In that case, `ssh root@dpu` works.

- the "iso" argument now supports http/https URLs, in which case the ISO will first be downloaded to `/host/root/rhel-iso*` (if it doesn't exist). Also supports `rhel:9.x` to automatically find the URL for the latest nightly. Also support `rhel:` where the RHEL version is determined by the tool (currently 9.4).