### PR TITLE
[th/cleanup-calling-scripts] minor cleanups for how we call the tools

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -28,5 +28,6 @@ COPY ./manifests /marvell-octeon-10-tools/manifests
 
 COPY manifests/.minirc.dfl /root/
 
+WORKDIR /marvell-octeon-10-tools
 ENTRYPOINT ["/usr/bin/tini", "-s", "-p", "SIGTERM", "-g", "-e", "143", "--"]
 CMD ["/usr/bin/sleep", "infinity"]

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ Marvell Octeon 10 Tools
 
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest
-sudo podman run --pull always --replace --pid host --network host --user 0 --name marvell-tools -dit --privileged -v /dev:/dev "$IMAGE"
-sudo podman exec -it marvell-tools <cmd>
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" <cmd>
 ```
 
 ## Tools
@@ -15,7 +14,9 @@ Utilize the serial interface at /dev/ttyUSB1 to trigger a reset of the associate
 
 Usage:
 ```
-python /marvell-octeon-10-tools/reset.py
+IMAGE=quay.io/sdaniele/marvell-tools:latest
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
+  ./reset.py
 ```
 
 ### PxeBoot
@@ -25,8 +26,8 @@ Utilize the serial interface at /dev/ttyUSB0 to pxeboot the card with the provid
 Usage:
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest
-sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -dit "$IMAGE"
-sudo podman exec -it marvell-tools python /marvell-octeon-10-tools/pxeboot.py --dev eno4 /host/root/RHEL-9.4.0-20240312.96-aarch64-dvd1.iso
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
+  ./pxeboot.py --dev eno4 /host/root/RHEL-9.4.0-20240312.96-aarch64-dvd1.iso
 ```
 
 ### FW Updater
@@ -36,9 +37,8 @@ Utilize the serial interface at /dev/ttyUSB0 to update the card with the provide
 Usage:
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest
-sudo podman run --pull always --replace --pid host --network host --user 0 --name marvell-tools -dit --privileged -v /dev:/dev -v /root/flash-uefi-cn10ka-11.24.02.img:/tmp/img "$IMAGE"
-sudo podman exec -it marvell-tools /bin/bash
-python /marvell-octeon-10-tools/fwupdate.py --dev eno4 /tmp/img
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
+  ./fwupdate.py --dev eno4 /host/root/flash-uefi-cn10ka-11.24.02.img
 ```
 
 

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import os
 import pexpect

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import http.server
 import os

--- a/reset.py
+++ b/reset.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import pexpect
 import time
 


### PR DESCRIPTION
- Containerfile: set default WORKDIR to "/marvell-octeon-10-tools"
- all: make main commands as executable scripts
- README: update usage examples to use podman-run and map /host
