### PR TITLE
[th/ktoolbox] ktoolbox: add "ktoolbox" package from "ocp-traffic-flow-tests" repository

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -21,6 +21,9 @@ jobs:
         python -m pip install black
         python -m pip install flake8
         python -m pip install mypy
+        python -m pip install pytest
+        python -m pip install types-PyYAML
+        python -m pip install types-paramiko
         python -m pip install -r requirements.txt
     - name: Check code formatting with Black
       run: |
@@ -34,3 +37,7 @@ jobs:
       run: |
        mypy --version
        mypy --strict --config-file mypy.ini .
+    - name: Run tests with Pytest
+      run: |
+       pytest --version
+       pytest -vv .

--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,10 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         python-unversioned-command \
         python3-pexpect \
         python3-pip \
+        python3-pyserial \
+        python3-pyyaml \
         python3-requests \
+        python3-types-pyyaml \
         python39 \
         tftp \
         tftp-server \
@@ -23,7 +26,8 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         -y && \
     echo "export PYTHONPATH=/marvell-octeon-10-tools" > /etc/profile.d/marvell-octeon-10-tools.sh
 
-COPY ./*.py ./*sh /marvell-octeon-10-tools/
+COPY ./*.py ./*sh ./mypy.ini /marvell-octeon-10-tools/
+COPY ktoolbox/README.md ktoolbox/*.py /marvell-octeon-10-tools/ktoolbox/
 COPY ./manifests /marvell-octeon-10-tools/manifests
 
 COPY manifests/.minirc.dfl /root/

--- a/ktoolbox/README.md
+++ b/ktoolbox/README.md
@@ -1,0 +1,11 @@
+ktoolbox
+=======
+
+Then `ktoolbox` package contains some basic utilities. It's (current) primary location is
+ocp-traffic-flow-tests ([1]), but it can be reused by just copying the entire directory.
+
+[1] https://github.com/wizhaoredhat/ocp-traffic-flow-tests/tree/main/ktoolbox
+
+If you copy/fork the directory, make sure to not modify the fork. Instead,
+extend the primary location first, and then reimport all files. This is to
+avoid diverging implementations. It requires self-constraint.

--- a/ktoolbox/common.py
+++ b/ktoolbox/common.py
@@ -1,0 +1,1221 @@
+import abc
+import contextlib
+import dataclasses
+import functools
+import json
+import os
+import re
+import time
+import typing
+
+from collections.abc import Iterable
+from collections.abc import Mapping
+from dataclasses import dataclass
+from dataclasses import fields
+from dataclasses import is_dataclass
+from enum import Enum
+from typing import Any
+from typing import Literal
+from typing import Optional
+from typing import Type
+from typing import TypeVar
+from typing import Union
+from typing import cast
+
+if typing.TYPE_CHECKING:
+    # https://github.com/python/typeshed/tree/main/stdlib/_typeshed#api-stability
+    # https://github.com/python/typeshed/blob/6220c20d9360b12e2287511587825217eec3e5b5/stdlib/_typeshed/__init__.pyi#L349
+    from _typeshed import DataclassInstance
+    from types import TracebackType
+
+
+PathType = Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]
+
+E = TypeVar("E", bound=Enum)
+T = TypeVar("T")
+TOptionalStr = TypeVar("TOptionalStr", bound=Optional[str])
+TOptionalInt = TypeVar("TOptionalInt", bound=Optional[int])
+TOptionalBool = TypeVar("TOptionalBool", bound=Optional[bool])
+TOptionalFloat = TypeVar("TOptionalFloat", bound=Optional[float])
+T1 = TypeVar("T1")
+T2 = TypeVar("T2")
+TCallable = typing.TypeVar("TCallable", bound=typing.Callable[..., typing.Any])
+TStructParseBaseNamed = typing.TypeVar(
+    "TStructParseBaseNamed", bound="StructParseBaseNamed"
+)
+
+
+# This is used as default value for some arguments, to recognize that the
+# caller didn't specify the argument. This is useful, when we want to
+# explicitly distinguish between having an argument unset or set to any value.
+# The caller would never pass this value, but the implementation would check
+# whether the argument is still left at the default.
+#
+# See also, dataclasses.MISSING and dataclasses._MISSING_TYPE
+class _MISSING_TYPE:
+    pass
+
+
+MISSING = _MISSING_TYPE()
+
+# kw_only is Python3.10+. This annotation is very useful, so make it available
+# with 3.9 without breaking mypy.
+#
+# This silences up mypy while retaining the error checking at runtime. It however
+# looses the ability for mypy to detect the error at lint time.
+#
+# So, using this acts as a comment to the reader that the code expects kw_only.
+# It is also enforced at runtime. It also allows to find all the places where
+# we would like to use kw_only=True but cannot due to Python 3.9 compatibility.
+KW_ONLY_DATACLASS = {"kw_only": True} if "kw_only" in dataclass.__kwdefaults__ else {}
+
+
+def bool_to_str(val: bool, *, format: str = "true") -> str:
+    if format == "true":
+        return "true" if val else "false"
+    if format == "yes":
+        return "yes" if val else "no"
+    raise ValueError(f'Invalid format "{format}"')
+
+
+def str_to_bool(
+    val: Optional[Union[str, bool]],
+    on_error: Union[T1, _MISSING_TYPE] = MISSING,
+    *,
+    on_default: Union[T2, _MISSING_TYPE] = MISSING,
+) -> Union[bool, T1, T2]:
+
+    is_default = False
+
+    if isinstance(val, str):
+        val2 = val.lower().strip()
+        if val2 in ("1", "y", "yes", "true", "on"):
+            return True
+        if val2 in ("0", "n", "no", "false", "off"):
+            return False
+        if val2 in ("", "default", "-1"):
+            is_default = True
+    elif val is None:
+        # None is (maybe) accepted as default value.
+        is_default = True
+    elif isinstance(val, bool):
+        # For convenience, also accept that the value is already a boolean.
+        return val
+
+    if is_default and not isinstance(on_default, _MISSING_TYPE):
+        # The value is explicitly set to one of the recognized default values
+        # (None, "default", "-1" or "").
+        #
+        # By setting @on_default, the caller can use str_to_bool() to not only
+        # parse boolean values, but ternary values.
+        return on_default
+
+    if not isinstance(on_error, _MISSING_TYPE):
+        # On failure, we return the fallback value.
+        return on_error
+
+    raise ValueError(f"Value {val} is not a boolean")
+
+
+def iter_get_first(
+    lst: Iterable[T],
+    *,
+    unique: bool = False,
+    force_unique: bool = False,
+) -> Optional[T]:
+    v0: Optional[T] = None
+    for idx, v in enumerate(lst):
+        if idx == 0:
+            v0 = v
+            continue
+        if force_unique:
+            raise RuntimeError("Iterable was expected to only contain one entry")
+        if unique:
+            # We have more than one entries. The caller requested to reject
+            # that.
+            return None
+        return v0
+    return v0
+
+
+def iter_filter_none(lst: Iterable[Optional[T]]) -> Iterable[T]:
+    for v in lst:
+        if v is not None:
+            yield v
+
+
+def unwrap(val: Optional[T], *, or_else: Optional[T] = None) -> T:
+    # Like Rust's unwrap. Get the value or die (with an exception).
+    #
+    # The error message here is not good, so this function is more for
+    # asserting (and shutting up the type checker) in cases where we
+    # expect to have a value.
+    if val is None:
+        if or_else is not None:
+            return or_else
+        raise ValueError("Optional value unexpectedly not set")
+    return val
+
+
+def enum_convert(
+    enum_type: Type[E],
+    value: Any,
+    default: Optional[E] = None,
+) -> E:
+
+    if value is None:
+        # We only allow None, if the caller also specified a default value.
+        if default is not None:
+            return default
+    elif isinstance(value, enum_type):
+        return value
+    elif isinstance(value, int):
+        try:
+            return enum_type(value)
+        except ValueError:
+            raise ValueError(f"Cannot convert {value} to {enum_type}")
+    elif isinstance(value, str):
+        v = value.strip()
+
+        # Try lookup by name.
+        try:
+            return enum_type[v]
+        except KeyError:
+            pass
+
+        # Try the string as integer value.
+        try:
+            return enum_type(int(v))
+        except Exception:
+            pass
+
+        # Finally, try again with all upper case. Also, all "-" are replaced
+        # with "_", but only if the result is unique.
+        v2 = v.upper().replace("-", "_")
+        matches = [e for e in enum_type if e.name.upper() == v2]
+        if len(matches) == 1:
+            return matches[0]
+
+        raise ValueError(f"Cannot convert {value} to {enum_type}")
+
+    raise ValueError(f"Invalid type for conversion to {enum_type}")
+
+
+def enum_convert_list(enum_type: Type[E], value: Any) -> list[E]:
+    output: list[E] = []
+
+    if isinstance(value, str):
+        for part in value.split(","):
+            part = part.strip()
+            if not part:
+                # Empty words are silently skipped.
+                continue
+
+            cases: Optional[list[E]] = None
+
+            # Try to parse as a single enum value.
+            try:
+                cases = [enum_convert(enum_type, part)]
+            except Exception:
+                cases = None
+
+            if part == "*":
+                # Shorthand for the entire range (sorted by numeric values)
+                cases = sorted(enum_type, key=lambda e: e.value)
+
+            if cases is None:
+                # Could not be parsed as single entry. Try to parse as range.
+
+                def _range_endpoint(s: str) -> int:
+                    try:
+                        return int(s)
+                    except Exception:
+                        pass
+                    return cast(int, enum_convert(enum_type, s).value)
+
+                try:
+                    # Try to detect this as range. Both end points may either by
+                    # an integer or an enum name.
+                    #
+                    # Note that since we use "-" to denote the range, we cannot have
+                    # a range that involves negative enum values (otherwise, enum_convert()
+                    # is fine to parse a single enum from a negative number in a string).
+                    start, end = [_range_endpoint(s) for s in part.split("-")]
+                except Exception:
+                    # Couldn't parse as range.
+                    pass
+                else:
+                    # We have a range.
+                    cases = None
+                    for i in range(start, end + 1):
+                        try:
+                            e = enum_convert(enum_type, i)
+                        except Exception:
+                            # When specifying a range, then missing enum values are
+                            # silently ignored. Note that as a whole, the range may
+                            # still not be empty.
+                            continue
+                        if cases is None:
+                            cases = []
+                        cases.append(e)
+
+            if cases is None:
+                raise ValueError(f"Invalid test case id: {part}")
+
+            output.extend(cases)
+    elif isinstance(value, list):
+        for idx, part in enumerate(value):
+            # First, try to parse the list entry with plain enum_convert.
+            cases = None
+            try:
+                cases = [enum_convert(enum_type, part)]
+            except Exception:
+                # Now, try to parse as a list (but only if we have a string, no lists in lists).
+                if isinstance(part, str):
+                    try:
+                        cases = enum_convert_list(enum_type, part)
+                    except Exception:
+                        pass
+            if not cases:
+                raise ValueError(
+                    f'list at index {idx} contains invalid value "{part}" for enum {enum_type}'
+                )
+            output.extend(cases)
+    else:
+        raise ValueError(f"Invalid {enum_type} value of type {type(value)}")
+
+    return output
+
+
+def json_parse_list(jstr: str, *, strict_parsing: bool = False) -> list[Any]:
+    try:
+        lst = json.loads(jstr)
+    except ValueError:
+        if strict_parsing:
+            raise
+        return []
+
+    if not isinstance(lst, list):
+        if strict_parsing:
+            raise ValueError("JSON data does not contain a list")
+        return []
+
+    return lst
+
+
+def dict_add_optional(vdict: dict[T1, T2], key: T1, val: Optional[T2]) -> None:
+    if val is not None:
+        vdict[key] = val
+
+
+@typing.overload
+def dict_get_typed(
+    d: Mapping[Any, Any],
+    key: Any,
+    vtype: type[T],
+    *,
+    allow_missing: Literal[False] = False,
+) -> T:
+    pass
+
+
+@typing.overload
+def dict_get_typed(
+    d: Mapping[Any, Any],
+    key: Any,
+    vtype: type[T],
+    *,
+    allow_missing: bool = False,
+) -> Optional[T]:
+    pass
+
+
+def dict_get_typed(
+    d: Mapping[Any, Any],
+    key: Any,
+    vtype: type[T],
+    *,
+    allow_missing: bool = False,
+) -> Optional[T]:
+    try:
+        v = d[key]
+    except KeyError:
+        if allow_missing:
+            return None
+        raise KeyError(f'missing key "{key}"')
+    if not isinstance(v, vtype):
+        raise TypeError(f'key "{key}" expected type {vtype} but has value "{v}"')
+    return v
+
+
+def serialize_enum(
+    data: Union[Enum, dict[Any, Any], list[Any], Any]
+) -> Union[str, dict[Any, Any], list[Any], Any]:
+    if isinstance(data, Enum):
+        return data.name
+    elif isinstance(data, dict):
+        return {k: serialize_enum(v) for k, v in data.items()}
+    elif isinstance(data, list):
+        return [serialize_enum(item) for item in data]
+    else:
+        return data
+
+
+def dataclass_to_dict(obj: "DataclassInstance") -> dict[str, Any]:
+    d = dataclasses.asdict(obj)
+    return typing.cast(dict[str, Any], serialize_enum(d))
+
+
+def dataclass_to_json(obj: "DataclassInstance") -> str:
+    d = dataclass_to_dict(obj)
+    return json.dumps(d)
+
+
+# Takes a dataclass and the dict you want to convert from
+# If your dataclass has a dataclass member, it handles that recursively
+def dataclass_from_dict(cls: Type[T], data: dict[str, Any]) -> T:
+    if not is_dataclass(cls):
+        raise ValueError(
+            f"dataclass_from_dict() should only be used with dataclasses but is called with {cls}"
+        )
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"requires a dictionary to in initialize dataclass {cls} but got {type(data)}"
+        )
+    for k in data:
+        if not isinstance(k, str):
+            raise ValueError(
+                f"requires a strdict to in initialize dataclass {cls} but has key {type(k)}"
+            )
+    data = dict(data)
+    create_kwargs = {}
+    for field in fields(cls):
+        if field.name not in data:
+            if (
+                field.default is dataclasses.MISSING
+                and field.default_factory is dataclasses.MISSING
+            ):
+                raise ValueError(
+                    f'Missing mandatory argument "{field.name}" for dataclass {cls}'
+                )
+            continue
+
+        if not field.init:
+            continue
+
+        def convert_simple(ck_type: Any, value: Any) -> Any:
+            if is_dataclass(ck_type) and isinstance(value, dict):
+                return dataclass_from_dict(ck_type, value)
+            if actual_type is None and issubclass(ck_type, Enum):
+                return enum_convert(ck_type, value)
+            if ck_type is float and isinstance(value, int):
+                return float(value)
+            return value
+
+        actual_type = typing.get_origin(field.type)
+
+        value = data.pop(field.name)
+
+        converted = False
+
+        if actual_type is typing.Union:
+            # This is an Optional[]. We already have a value, we check for the requested
+            # type. check_type() already implements this, but we need to also check
+            # it here, for the dataclass/enum handling below.
+            args = typing.get_args(field.type)
+            ck_type = None
+            if len(args) == 2:
+                NoneType = type(None)
+                if args[0] is NoneType:
+                    ck_type = args[1]
+                elif args[1] is NoneType:
+                    ck_type = args[0]
+            if ck_type is not None:
+                value_converted = convert_simple(ck_type, value)
+                converted = True
+        elif actual_type is list:
+            args = typing.get_args(field.type)
+            if isinstance(value, list) and len(args) == 1:
+                value_converted = [convert_simple(args[0], v) for v in value]
+                converted = True
+
+        if not converted:
+            value_converted = convert_simple(field.type, value)
+
+        if not check_type(value_converted, field.type):
+            raise TypeError(
+                f"Expected type '{field.type}' for attribute '{field.name}' but received type '{type(value)}' ({value})"
+            )
+
+        create_kwargs[field.name] = value_converted
+
+    if data:
+        raise ValueError(
+            f"There are left over keys {list(data)} to create dataclass {cls}"
+        )
+
+    return cast(T, cls(**create_kwargs))
+
+
+def check_type(
+    value: typing.Any,
+    type_hint: Union[type[typing.Any], typing._SpecialForm],
+) -> bool:
+
+    # Some naive type checking. This is used for ensuring that data classes
+    # contain the expected types (see @strict_dataclass).
+    #
+    # That is most interesting, when we initialize the data class with
+    # data from an untrusted source (like elements from a JSON parser).
+
+    actual_type = typing.get_origin(type_hint)
+    if actual_type is None:
+        if isinstance(type_hint, str):
+            raise NotImplementedError(
+                f'Type hint "{type_hint}" as string is not implemented by check_type()'
+            )
+
+        if type_hint is typing.Any:
+            return True
+        return isinstance(value, typing.cast(Any, type_hint))
+
+    if actual_type is typing.Union:
+        args = typing.get_args(type_hint)
+        return any(check_type(value, a) for a in args)
+
+    if actual_type is list:
+        args = typing.get_args(type_hint)
+        (arg,) = args
+        return isinstance(value, list) and all(check_type(v, arg) for v in value)
+
+    if actual_type is dict or actual_type is Mapping:
+        args = typing.get_args(type_hint)
+        (arg_key, arg_val) = args
+        return isinstance(value, dict) and all(
+            check_type(k, arg_key) and check_type(v, arg_val) for k, v in value.items()
+        )
+
+    if actual_type is tuple:
+        # https://docs.python.org/3/library/typing.html#annotating-tuples
+        if not isinstance(value, tuple):
+            return False
+        args = typing.get_args(type_hint)
+        if len(args) == 1 and args[0] == ():
+            # This is an empty tuple tuple[()].
+            return len(value) == 0
+        if len(args) == 2 and args[1] is ...:
+            # This is a tuple[T, ...].
+            return all(check_type(v, args[0]) for v in value)
+        return len(value) == len(args) and all(
+            check_type(v, args[idx]) for idx, v in enumerate(value)
+        )
+
+    raise NotImplementedError(
+        f'Type hint "{type_hint}" with origin type "{actual_type}" is not implemented by check_type()'
+    )
+
+
+def dataclass_check(
+    instance: "DataclassInstance",
+    *,
+    with_post_check: bool = True,
+) -> None:
+
+    for field in dataclasses.fields(instance):
+        value = getattr(instance, field.name)
+        if not check_type(value, field.type):
+            raise TypeError(
+                f"Expected type '{field.type}' for attribute '{field.name}' but received type '{type(value)}' ({value})"
+            )
+
+    if with_post_check:
+        # Normally, data classes support __post_init__(), which is called by __init__()
+        # already. Add a way for a @strict_dataclass to add additional validation *after*
+        # the original check.
+        _post_check = getattr(type(instance), "_post_check", None)
+        if _post_check is not None:
+            _post_check(instance)
+
+
+def strict_dataclass(cls: TCallable) -> TCallable:
+
+    init = getattr(cls, "__init__")
+
+    def wrapped_init(self: Any, *args: Any, **argv: Any) -> None:
+        init(self, *args, **argv)
+        dataclass_check(self)
+
+    setattr(cls, "__init__", wrapped_init)
+    return cls
+
+
+def structparse_check_strdict(arg: Any, yamlpath: str) -> dict[str, Any]:
+    """
+    Checks that "args" is a strdict and returns a shallow copy
+    of the dictionary.
+
+    The usage is then to pop keys from the dictionary (structparse_pop_*())
+    and at the end check that no more (unknown) keys are left (structparse_check_empty_dict()).
+    """
+    if not isinstance(arg, dict):
+        raise ValueError(f'"{yamlpath}": expects a dictionary but got {type(arg)}')
+    for k, v in arg.items():
+        if not isinstance(k, str):
+            raise ValueError(
+                f'"{yamlpath}": expects all dictionary keys to be strings but got {type(k)}'
+            )
+
+    # We shallow-copy the dictionary, because the caller will remove entries
+    # to find unknown entries (see _check_empty_dict()).
+    return dict(arg)
+
+
+def structparse_check_empty_dict(vdict: dict[str, Any], yamlpath: str) -> None:
+    """
+    Checks that "vdict" is empty or fail with an exception.
+
+    The usage is to first shallow copy the dictionary (with structparse_check_strdict()),
+    the pop all known keys (structparse_pop_*()), and finally check that no (unknown)
+    keys are left. Possibly use this via "with structparse_with_strdict() as varg".
+    """
+    length = len(vdict)
+    if length == 1:
+        raise ValueError(f'"{yamlpath}": unknown key {repr(list(vdict)[0])}')
+    if length > 1:
+        raise ValueError(f'"{yamlpath}": unknown keys {list(vdict)}')
+
+
+@dataclass(frozen=True)
+class StructParseVarg:
+    vdict: dict[str, Any]
+    yamlpath: str
+    check_empty: bool = dataclasses.field(default=True, init=False)
+
+    def for_key(self, key: str) -> tuple[dict[str, Any], str, str]:
+        """
+        Returns a tuple of [vdict, yamlpath, key].
+
+        This is for convenience, to pass to the structparse_pop_*() functions
+        with less redundant typing. In particular, when wrapping lines, this
+        only expands to one line instead of three, making it more compact to
+        read.
+
+        Example:
+
+           foo = structparse_pop_str(*varg.for_key("foo"))
+        """
+        return self.vdict, self.yamlpath, key
+
+    def for_name(self, key: str = "name") -> tuple[dict[str, Any], str, str]:
+        """
+        Same as for_key(), but defaults to a key "name".
+
+        Example:
+
+           foo = structparse_pop_str_name(*varg.for_name())
+        """
+        return self.vdict, self.yamlpath, key
+
+    def skip_check_empty(self) -> None:
+        """
+        With structparse_with_strdict(), indicate that the final
+        structparse_check_empty_dict() should be skipped.
+        """
+        object.__setattr__(self, "check_empty", False)
+
+
+@contextlib.contextmanager
+def structparse_with_strdict(
+    arg: Any,
+    yamlpath: str,
+) -> typing.Generator[StructParseVarg, None, None]:
+    """
+    Context manager for parsing a strdict.
+
+    arg: the argument, which is validated to be a string dictinary.
+    yamlpath: the YAML path for "arg".
+
+    Example:
+
+        with structparse_with_strdict(arg, yamlpath) as varg:
+            name = structparse_pop_str_name(*varg.for_name())
+            foo = structparse_pop_int(*varg.for_key("foo"), default=None)
+
+    Above is basically the same as
+
+        vdict = structparse_check_strdict(arg, yamlpath)
+        name = structparse_pop_str_name(vdict, yamlpath, "name")
+        foo = structparse_pop_int(vdict, yamlpath, "foo", default=None)
+        structparse_check_empty_dict(vdict)
+    """
+    vdict = structparse_check_strdict(arg, yamlpath)
+    varg = StructParseVarg(vdict, yamlpath)
+    yield varg
+    if varg.check_empty:
+        structparse_check_empty_dict(vdict, yamlpath)
+
+
+def structparse_pop_str(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    default: Union[TOptionalStr, _MISSING_TYPE] = MISSING,
+    empty_as_default: Optional[bool] = None,
+    allow_empty: Optional[bool] = None,
+    check: Optional[typing.Callable[[str], bool]] = None,
+) -> Union[str, TOptionalStr]:
+    """
+    Pop "key" from "vdict", validates that it's a string and returns it.
+    If "default" is given it is returned for missing keys. Otherwise,
+    the key is mandatory.
+    """
+    # The arguments allow to carefully control what happens with empty
+    # values. Usually, most parameters are unset by the caller, so we
+    # must determine their actual values depending on the parameters
+    # we have. It's chosen in a way, so that it makes the most sense
+    # for the caller.
+    if allow_empty is None:
+        # "allow_empty" will default to True, if "empty_as_default" is set.
+        if empty_as_default is not None:
+            allow_empty = True
+    if empty_as_default is None:
+        # "empty_as_default" defaults to True, if "allow_empty" is True.
+        empty_as_default = allow_empty is None or not allow_empty
+    if allow_empty is None:
+        # At this point, if "allow_empty" is still undecided, we allow
+        # it if "empty_as_default" or if we have a "check".
+        allow_empty = empty_as_default or check is not None
+    if not allow_empty:
+        empty_as_default = False
+
+    v = vdict.pop(key, None)
+    if v is not None and not isinstance(v, str):
+        raise ValueError(f'"{yamlpath}.{key}": expects a string but got {v}')
+    if v is None or (not v and empty_as_default):
+        if isinstance(default, _MISSING_TYPE):
+            raise ValueError(f'"{yamlpath}.{key}": mandatory key missing')
+        return default
+    if not v:
+        if not allow_empty:
+            raise ValueError(f'"{yamlpath}.{key}": cannot be an empty string')
+    if check is not None:
+        if not check(v):
+            raise ValueError(f'"{yamlpath}.{key}": invalid string')
+    return v
+
+
+def structparse_pop_str_name(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str = "name",
+    *,
+    default: Union[TOptionalStr, _MISSING_TYPE] = MISSING,
+) -> Union[str, TOptionalStr]:
+    return structparse_pop_str(
+        vdict,
+        yamlpath,
+        key=key,
+        default=default,
+        allow_empty=False,
+    )
+
+
+def structparse_pop_int(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    default: Union[TOptionalInt, _MISSING_TYPE] = MISSING,
+    check: Optional[typing.Callable[[int], bool]] = None,
+    description: str = "a number",
+) -> Union[int, TOptionalInt]:
+    v = vdict.pop(key, None)
+    if v is None:
+        if isinstance(default, _MISSING_TYPE):
+            raise ValueError(
+                f'"{yamlpath}.{key}": requires {description}',
+            )
+        return default
+    try:
+        val = int(v)
+    except Exception:
+        raise ValueError(f'"{yamlpath}.{key}": expects {description} but got {repr(v)}')
+    if check is not None:
+        if not check(val):
+            raise ValueError(
+                f'"{yamlpath}.{key}": expects {description} but got {repr(v)}'
+            )
+    return val
+
+
+def structparse_pop_float(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    default: Union[TOptionalFloat, _MISSING_TYPE] = MISSING,
+    check: Optional[typing.Callable[[float], bool]] = None,
+    description: str = "a floating point number",
+) -> Union[float, TOptionalFloat]:
+    v = vdict.pop(key, None)
+    if v is None:
+        if isinstance(default, _MISSING_TYPE):
+            raise ValueError(
+                f'"{yamlpath}.{key}": requires {description}',
+            )
+        return default
+    try:
+        val = float(v)
+    except Exception:
+        raise ValueError(f'"{yamlpath}.{key}": expects {description} but got {repr(v)}')
+    if check is not None:
+        if not check(val):
+            raise ValueError(
+                f'"{yamlpath}.{key}": expects {description} but got {repr(v)}'
+            )
+    return val
+
+
+def structparse_pop_bool(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    default: Union[TOptionalBool, _MISSING_TYPE] = MISSING,
+    description: str = "a boolean",
+) -> Union[bool, TOptionalBool]:
+    v = vdict.pop(key, None)
+    try:
+        # Just like str_to_bool(), we accept "", "default", and "-1" as default
+        # values (if `default` is not MISSING).
+        return str_to_bool(v, on_default=default)
+    except Exception:
+        if v is None:
+            raise ValueError(f'"{yamlpath}.{key}": requires {description}')
+        raise ValueError(f'"{yamlpath}.{key}": expects {description} but got {repr(v)}')
+
+
+@typing.overload
+def structparse_pop_enum(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    enum_type: type[E],
+    default: Union[E, _MISSING_TYPE] = MISSING,
+) -> E:
+    pass
+
+
+@typing.overload
+def structparse_pop_enum(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    enum_type: type[E],
+    default: Literal[None],
+) -> Optional[E]:
+    pass
+
+
+def structparse_pop_enum(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    enum_type: type[E],
+    default: Union[Optional[E], _MISSING_TYPE] = MISSING,
+) -> Optional[E]:
+    v = vdict.pop(key, None)
+    if v is None:
+        if isinstance(default, _MISSING_TYPE):
+            raise ValueError(
+                f"\"{yamlpath}.{key}\": requires one of {', '.join(e.name for e in enum_type)}"
+            )
+        return default
+    if isinstance(default, _MISSING_TYPE):
+        default = None
+    try:
+        return enum_convert(enum_type, v, default=default)
+    except Exception:
+        raise ValueError(
+            f"\"{yamlpath}.{key}\": requires one of {', '.join(e.name for e in enum_type)} but got {repr(v)}"
+        )
+
+
+def structparse_pop_list(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    allow_missing: Optional[bool] = None,
+    allow_empty: bool = True,
+) -> list[Any]:
+    """
+    Checks that "key" is a list (of anything) and returns a shallow copy of the
+    list. This always returns a (potentially empty) list. By default, missing
+    key and empty list is allowed, but that can be restricted with the
+    "allow_missing" and "allow_empty" parameters.
+    """
+    if allow_missing is None:
+        allow_missing = allow_empty
+    v = vdict.pop(key, None)
+    if v is None:
+        if not allow_missing:
+            raise ValueError(f'"{yamlpath}.{key}": mandatory list argument missing')
+        # We never return None here. For many callers that is what we just
+        # want. For callers that want to do something specific if the key is
+        # unset, they should check first whether vdict contains the key.
+        return []
+    if not isinstance(v, list):
+        raise ValueError(f'"{yamlpath}.{key}": requires a list but got {type(v)}')
+    if not v:
+        if not allow_empty:
+            raise ValueError(f'"{yamlpath}.{key}": list cannot be empty')
+    # Return a shallow copy of the list.
+    return list(v)
+
+
+def structparse_pop_obj(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    construct: typing.Callable[[int, str, Any], T],
+    default: Union[T2, _MISSING_TYPE] = MISSING,
+    construct_default: bool = False,
+) -> Union[T, T2]:
+    """
+    Pops "key" from "vdict" and passes it to "construct" callback to parse
+    and construct a result.
+
+    By default, the key is mandatory. If "construct_default" is True,
+    for missing keys we pass None to "construct". This allows to generate
+    the callback a default value. Otherwise, if "default" is set, that
+    is returned for missing keys.
+    """
+    v = vdict.pop(key, None)
+    if not construct_default and v is None:
+        if isinstance(default, _MISSING_TYPE):
+            raise ValueError(f'"{yamlpath}.{key}": mandatory key missing')
+        return default
+    return construct(0, f"{yamlpath}.{key}", v)
+
+
+def structparse_pop_objlist(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    construct: typing.Callable[[int, str, Any], T],
+    allow_missing: Optional[bool] = None,
+    allow_empty: bool = True,
+) -> tuple[T, ...]:
+    v = structparse_pop_list(
+        vdict,
+        yamlpath,
+        key,
+        allow_missing=allow_missing,
+        allow_empty=allow_empty,
+    )
+    return tuple(
+        construct(
+            yamlidx2,
+            f"{yamlpath}.{key}[{yamlidx2}]",
+            arg2,
+        )
+        for yamlidx2, arg2 in enumerate(v)
+    )
+
+
+@typing.overload
+def structparse_pop_objlist_to_dict(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    construct: typing.Callable[[int, str, Any], TStructParseBaseNamed],
+    get_key: Literal[None] = None,
+    allow_empty: bool = True,
+    allow_duplicates: bool = False,
+) -> dict[str, TStructParseBaseNamed]:
+    pass
+
+
+@typing.overload
+def structparse_pop_objlist_to_dict(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    construct: typing.Callable[[int, str, Any], T],
+    get_key: typing.Callable[[T], T2],
+    allow_empty: bool = True,
+    allow_duplicates: bool = False,
+) -> dict[T2, T]:
+    pass
+
+
+def structparse_pop_objlist_to_dict(
+    vdict: dict[str, Any],
+    yamlpath: str,
+    key: str,
+    *,
+    construct: typing.Callable[[int, str, Any], T],
+    get_key: Optional[typing.Callable[[T], T2]] = None,
+    allow_empty: bool = True,
+    allow_duplicates: bool = False,
+) -> dict[T2, T]:
+    lst = structparse_pop_objlist(
+        vdict,
+        yamlpath,
+        key,
+        construct=construct,
+        allow_empty=allow_empty,
+    )
+    result: dict[T2, tuple[int, T]] = {}
+    for yamlidx2, item in enumerate(lst):
+        if get_key is not None:
+            item_key = get_key(item)
+        else:
+            if not isinstance(item, StructParseBaseNamed):
+                raise RuntimeError(
+                    f"list requires StructParseBaseNamed elements but we got {type(item)}"
+                )
+            item_key = typing.cast("T2", item.name)
+        item2 = result.get(item_key, None)
+        if item2 is not None:
+            if allow_duplicates:
+                # We allow duplicates. Last occurrence wins. We remove the old
+                # entry (because the dict is sorted, and we want to preserve the
+                # order.
+                del result[item_key]
+            else:
+                if isinstance(item_key, Enum):
+                    key_name = item_key.name
+                else:
+                    key_name = repr(item_key)
+                raise ValueError(
+                    f'"{yamlpath}.{key}[{yamlidx2}]": duplicate key {repr(key_name)} with "{yamlpath}.{key}[{item2[0]}]"'
+                )
+        result[item_key] = (yamlidx2, item)
+    return {k: v[1] for k, v in result.items()}
+
+
+@strict_dataclass
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class StructParseBase(abc.ABC):
+    yamlpath: str
+    yamlidx: int
+
+    @abc.abstractmethod
+    def serialize(self) -> Union[dict[str, Any], list[Any]]:
+        pass
+
+    def serialize_json(self) -> str:
+        return json.dumps(self.serialize())
+
+
+@strict_dataclass
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class StructParseBaseNamed(StructParseBase, abc.ABC):
+    name: str
+
+    def serialize(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+        }
+
+
+def repeat_for_same_result(fcn: TCallable) -> TCallable:
+    # This decorator wraps @fcn and will call it (up to 10 times) until the
+    # same result was returned twice in a row. The purpose is when we fetch
+    # several pieces of information form the system, that can change at any
+    # time. We would like to get a stable, self-consistent result.
+    @functools.wraps(fcn)
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        result = None
+        for i in range(10):
+            new_result = fcn(*args, **kwargs)
+            if i != 0 and result == new_result:
+                return new_result
+            result = new_result
+        return result
+
+    return typing.cast(TCallable, wrapped)
+
+
+def etc_hosts_update_data(
+    content: str,
+    new_entries: Mapping[str, tuple[str, Optional[Iterable[str]]]],
+) -> str:
+
+    lineregex = re.compile(r"^\s*[a-fA-F0-9:.]+\s+([-a-zA-Z0-9_.]+)(\s+.*)?$")
+
+    def _unpack(
+        v: tuple[str, Optional[Iterable[str]]]
+    ) -> Union[Literal[False], tuple[str, tuple[str, ...]]]:
+        n, a = v
+        if a is None:
+            a = ()
+        else:
+            a = tuple(a)
+        return n, a
+
+    entries = {k: _unpack(v) for k, v in new_entries.items()}
+
+    def _build_line(name: str, ipaddr: str, aliases: tuple[str, ...]) -> str:
+        if aliases:
+            s_aliases = f" {' '.join(aliases)}"
+        else:
+            s_aliases = ""
+        return f"{ipaddr} {name}{s_aliases}"
+
+    result = []
+    for line in content.splitlines():
+        m = lineregex.search(line)
+        if m:
+            name = m.group(1)
+            entry = entries.get(name)
+            if entry is None:
+                pass
+            elif entry is False:
+                continue
+            else:
+                line = _build_line(name, *entry)
+                entries[name] = False
+        result.append(line)
+
+    entries2 = [(k, v) for k, v in entries.items() if v is not False]
+    if entries2:
+        if result and result[-1] != "":
+            result.append("")
+        for name, entry in entries2:
+            result.append(_build_line(name, *entry))
+
+    if not result:
+        return ""
+
+    result.append("")
+    return "\n".join(result)
+
+
+def etc_hosts_update_file(
+    new_entries: Mapping[str, tuple[str, Optional[Iterable[str]]]],
+    filename: PathType = "/etc/hosts",
+) -> str:
+    try:
+        with open(filename, "rb") as f:
+            b_content = f.read()
+    except Exception:
+        b_content = b""
+
+    new_content = etc_hosts_update_data(
+        b_content.decode("utf-8", errors="surrogateescape"),
+        new_entries,
+    )
+
+    with open(filename, "wb") as f:
+        f.write(new_content.encode("utf-8", errors="surrogateescape"))
+
+    return new_content
+
+
+class Serial:
+    def __init__(self, port: str, baudrate: int = 115200):
+        import serial
+        from .logger import logger
+
+        self.port = port
+        self._ser = serial.Serial(port, baudrate=baudrate, timeout=0)
+        self._logger = logger
+        self._buffer = ""
+
+    @property
+    def buffer(self) -> str:
+        return self._buffer
+
+    def close(self) -> None:
+        self._ser.close()
+
+    def send(self, msg: str, *, sleep: float = 1) -> None:
+        self._logger.debug(f"serial[{self.port}]: send {repr(msg)}")
+        self._ser.write(msg.encode("utf-8", errors="surrogateescape"))
+        time.sleep(sleep)
+
+    def read_all(self) -> str:
+        maxsize = 1000000
+        while True:
+            buf: bytes = self._ser.read(maxsize)
+            self._buffer += buf.decode("utf-8", errors="surrogateescape")
+            if len(buf) < maxsize:
+                return self._buffer
+
+    def expect(
+        self,
+        pattern: Union[str, re.Pattern[str]],
+        timeout: float = 30,
+    ) -> str:
+        import select
+
+        end_timestamp = time.monotonic() + timeout
+        first_run = True
+
+        self._logger.debug(f"serial[{self.port}]: expect message {repr(pattern)}")
+
+        if isinstance(pattern, str):
+            # We use DOTALL like pexpect does.
+            # If you need something else, compile the pattern yourself.
+            #
+            # See also https://pexpect.readthedocs.io/en/stable/overview.html#find-the-end-of-line-cr-lf-conventions
+            pattern_re = re.compile(pattern, re.DOTALL)
+        else:
+            pattern_re = pattern
+
+        while True:
+
+            # First, read all data from the serial port that is currently available.
+            while True:
+                b: bytes = self._ser.read(100)
+                if not b:
+                    break
+                s = b.decode("utf-8", errors="surrogateescape")
+                self._logger.debug(
+                    f"serial[{self.port}]: read buffer ({len(self._buffer)} + {len(s)} unicode characters): {repr(s)}"
+                )
+                self._buffer += s
+
+            matches = re.finditer(pattern_re, self._buffer)
+            for match in matches:
+                end_idx = match.end()
+                self._logger.debug(
+                    f"serial[{self.port}]: found expected message {end_idx} unicode characters, {len(self._buffer) - end_idx} remaning"
+                )
+                self._buffer = self._buffer[end_idx:]
+                return self._buffer
+
+            if first_run:
+                first_run = False
+            else:
+                remaining_time = end_timestamp - time.monotonic()
+                if remaining_time <= 0:
+                    self._logger.debug(
+                        f"serial[{self.port}]: did not find expected message {repr(pattern)} (buffer content is {repr(self._buffer)})"
+                    )
+                    raise RuntimeError(
+                        f"Did not receive expected message {repr(pattern)} within timeout (buffer content is {repr(self._buffer)})"
+                    )
+                _, _, _ = select.select([self._ser], [], [], remaining_time)
+
+    def __enter__(self) -> "Serial":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional["TracebackType"],
+    ) -> None:
+        self._ser.close()

--- a/ktoolbox/firewall.py
+++ b/ktoolbox/firewall.py
@@ -1,0 +1,60 @@
+import shlex
+
+from . import host
+
+
+def _nft_cmd_table(*, up: bool, family: str, table_name: str) -> str:
+    return (
+        f"add table {family} {table_name}\n"
+        f"{'flush' if up else 'delete'} table {family} {table_name}\n"
+    )
+
+
+def nft_data_delete_table(
+    *,
+    family: str,
+    table_name: str,
+) -> str:
+    return _nft_cmd_table(up=False, family=family, table_name=table_name)
+
+
+def nft_data_masquerade_down(
+    table_name: str,
+) -> str:
+    return nft_data_delete_table(family="ip", table_name=table_name)
+
+
+def nft_data_masquerade_up(
+    *,
+    table_name: str,
+    subnet: str,
+    ifname: str,
+) -> str:
+    # Taken from NetworkManager:
+    # https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/8488162d1069defada6be0666175ffd10f333f9d/src/core/nm-firewall-utils.c#L688
+    return _nft_cmd_table(up=True, family="ip", table_name=table_name) + (
+        f"add chain ip {table_name} nat_postrouting {{"
+        " type nat hook postrouting priority 100; policy accept; "
+        "};\n"
+        f"add rule ip {table_name} nat_postrouting ip saddr {subnet} ip daddr != {subnet} masquerade;\n"
+        f"add chain ip {table_name} filter_forward {{"
+        " type filter hook forward priority 0; policy accept; "
+        "};\n"
+        f'add rule ip {table_name} filter_forward ip daddr {subnet} oifname "{ifname}" '
+        " ct state { established, related } accept;\n"
+        f'add rule ip {table_name} filter_forward ip saddr {subnet} iifname "{ifname}" accept;\n'
+        f'add rule ip {table_name} filter_forward iifname "{ifname}" oifname "{ifname}" accept;\n'
+        f'add rule ip {table_name} filter_forward iifname "{ifname}" reject;\n'
+        f'add rule ip {table_name} filter_forward oifname "{ifname}" reject;\n'
+    )
+
+
+def nft_call(
+    data: str,
+    rsh: host.Host = host.local,
+    *,
+    nft_cmd: str = "nft",
+) -> bool:
+    return rsh.run(
+        f"printf '%s' {shlex.quote(data)} | {shlex.quote(nft_cmd)} -f -"
+    ).success

--- a/ktoolbox/host.py
+++ b/ktoolbox/host.py
@@ -1,0 +1,832 @@
+import dataclasses
+import logging
+import os
+import select
+import shlex
+import subprocess
+import sys
+import threading
+import time
+import typing
+
+from abc import ABC
+from abc import abstractmethod
+from collections.abc import Iterable
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Union
+
+from .logger import logger
+
+INTERNAL_ERROR_PREFIX = "Host.run(): "
+INTERNAL_ERROR_RETURNCODE = 1
+
+
+_lock = threading.Lock()
+
+_unique_log_id_value = 0
+
+# Same as common.KW_ONLY_DATACLASS, but we should not use common module here.
+# See common.KW_ONLY_DATACLASS why this is used.
+KW_ONLY_DATACLASS = {"kw_only": True} if "kw_only" in dataclass.__kwdefaults__ else {}
+
+
+def _normalize_cmd(
+    cmd: Union[str, Iterable[str]],
+) -> Union[str, tuple[str, ...]]:
+    if isinstance(cmd, str):
+        return cmd
+    else:
+        return tuple(cmd)
+
+
+def _normalize_env(
+    env: Optional[Mapping[str, Optional[str]]],
+) -> Optional[dict[str, Optional[str]]]:
+    if env is None:
+        return None
+    return dict(env)
+
+
+def _cmd_to_logstr(cmd: Union[str, tuple[str, ...]]) -> str:
+    return repr(_cmd_to_shell(cmd))
+
+
+def _cmd_to_shell(
+    cmd: Union[str, Iterable[str]],
+    *,
+    cwd: Optional[str] = None,
+) -> str:
+    if not isinstance(cmd, str):
+        cmd = shlex.join(cmd)
+    if cwd is not None:
+        cmd = f"cd {shlex.quote(cwd)} || exit 1 ; {cmd}"
+    return cmd
+
+
+def _cmd_to_argv(cmd: Union[str, Iterable[str]]) -> tuple[str, ...]:
+    if isinstance(cmd, str):
+        return ("/bin/sh", "-c", cmd)
+    return tuple(cmd)
+
+
+def _unique_log_id() -> int:
+    # For each run() call, we log a message when starting the command and when
+    # completing it. Add a unique number to those logging statements, so that
+    # we can easier find them in a large log.
+    with _lock:
+        global _unique_log_id_value
+        _unique_log_id_value += 1
+        return _unique_log_id_value
+
+
+T = typing.TypeVar("T", bound=Union[str, bytes])
+
+
+@dataclass(frozen=True)
+class _BaseResult(ABC, typing.Generic[T]):
+    # _BaseResult only exists to have the first 3 parameters positional
+    # arguments and the subsequent parameters (in BaseResult) marked as
+    # KW_ONLY_DATACLASS. Once we no longer support Python 3.9, the classes
+    # can be merged.
+    out: T
+    err: T
+    returncode: int
+
+
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class BaseResult(_BaseResult[T]):
+    # In most cases, "success" is the same as checking for returncode zero.  In
+    # some cases, it can be overwritten to be of a certain value.
+    forced_success: Optional[bool] = dataclasses.field(
+        default=None,
+        # kw_only=True <- use once we upgrade to 3.10 and drop KW_ONLY_DATACLASS.
+    )
+
+    @property
+    def success(self) -> bool:
+        if self.forced_success is not None:
+            return self.forced_success
+        return self.returncode == 0
+
+    def debug_str(self, *, with_output: bool = True) -> str:
+        if self.forced_success is None or self.forced_success == (self.returncode == 0):
+            if self.success:
+                status = "success"
+            else:
+                status = f"failed (exit {self.returncode})"
+        else:
+            if self.forced_success:
+                status = f"success [forced] (exit {self.returncode})"
+            else:
+                status = "failed [forced] (exit 0)"
+
+        out = ""
+        if self.out and with_output:
+            out = f"; out={repr(self.out)}"
+
+        err = ""
+        if self.err and with_output:
+            err = f"; err={repr(self.err)}"
+
+        return f"{status}{out}{err}"
+
+    def debug_msg(self) -> str:
+        return f"cmd {self.debug_str()}"
+
+
+@dataclass(frozen=True)
+class Result(BaseResult[str]):
+    def dup_with_forced_success(self, forced_success: bool) -> "Result":
+        if forced_success == self.success:
+            return self
+        return Result(
+            self.out,
+            self.err,
+            self.returncode,
+            forced_success=forced_success,
+        )
+
+
+@dataclass(frozen=True)
+class BinResult(BaseResult[bytes]):
+    def decode(self, errors: str = "strict") -> Result:
+        return Result(
+            self.out.decode(errors=errors),
+            self.err.decode(errors=errors),
+            self.returncode,
+        )
+
+    def dup_with_forced_success(self, forced_success: bool) -> "BinResult":
+        if forced_success == self.success:
+            return self
+        return BinResult(
+            self.out,
+            self.err,
+            self.returncode,
+            forced_success=forced_success,
+        )
+
+    @staticmethod
+    def internal_failure(msg: str) -> "BinResult":
+        return BinResult(
+            b"",
+            (INTERNAL_ERROR_PREFIX + msg).encode(errors="surrogateescape"),
+            INTERNAL_ERROR_RETURNCODE,
+        )
+
+
+class Host(ABC):
+    def __init__(
+        self,
+        *,
+        sudo: bool = False,
+    ) -> None:
+        self._sudo = sudo
+
+    @abstractmethod
+    def pretty_str(self) -> str:
+        pass
+
+    def _prepare_run(
+        self,
+        *,
+        sudo: bool,
+        cwd: Optional[str],
+        cmd: Union[str, Iterable[str]],
+        env: Optional[Mapping[str, Optional[str]]],
+    ) -> tuple[
+        Union[str, tuple[str, ...]],
+        Optional[dict[str, Optional[str]]],
+        Optional[str],
+    ]:
+        if not sudo:
+            return (
+                _normalize_cmd(cmd),
+                _normalize_env(env),
+                cwd,
+            )
+
+        cmd2 = ["sudo", "-n"]
+
+        if env:
+            for k, v in env.items():
+                assert k == shlex.quote(k)
+                assert "=" not in k
+                if v is not None:
+                    cmd2.append(f"{k}={v}")
+
+        if cwd is not None:
+            # sudo's "--chdir" option often does not work based on the sudo
+            # configuration. Instead, change the directory inside the shell
+            # script.
+            cmd = _cmd_to_shell(cmd, cwd=cwd)
+
+        cmd2.extend(_cmd_to_argv(cmd))
+
+        return tuple(cmd2), None, None
+
+    @typing.overload
+    def run(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        text: typing.Literal[True] = True,
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        sudo: Optional[bool] = None,
+        cwd: Optional[str] = None,
+        log_prefix: str = "",
+        log_level: int = logging.DEBUG,
+        log_level_result: Optional[int] = None,
+        log_level_fail: Optional[int] = None,
+        log_lineoutput: Union[bool, int] = False,
+        check_success: Optional[Callable[[Result], bool]] = None,
+        die_on_error: bool = False,
+        decode_errors: Optional[str] = None,
+    ) -> Result:
+        pass
+
+    @typing.overload
+    def run(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        text: typing.Literal[False],
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        sudo: Optional[bool] = None,
+        cwd: Optional[str] = None,
+        log_prefix: str = "",
+        log_level: int = logging.DEBUG,
+        log_level_result: Optional[int] = None,
+        log_level_fail: Optional[int] = None,
+        log_lineoutput: Union[bool, int] = False,
+        check_success: Optional[Callable[[BinResult], bool]] = None,
+        die_on_error: bool = False,
+        decode_errors: Optional[str] = None,
+    ) -> BinResult:
+        pass
+
+    @typing.overload
+    def run(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        text: bool = True,
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        sudo: Optional[bool] = None,
+        cwd: Optional[str] = None,
+        log_prefix: str = "",
+        log_level: int = logging.DEBUG,
+        log_level_result: Optional[int] = None,
+        log_level_fail: Optional[int] = None,
+        log_lineoutput: Union[bool, int] = False,
+        check_success: Optional[
+            Union[Callable[[Result], bool], Callable[[BinResult], bool]]
+        ] = None,
+        die_on_error: bool = False,
+        decode_errors: Optional[str] = None,
+    ) -> Union[Result, BinResult]:
+        pass
+
+    def run(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        text: bool = True,
+        env: Optional[Mapping[str, Optional[str]]] = None,
+        sudo: Optional[bool] = None,
+        cwd: Optional[str] = None,
+        log_prefix: str = "",
+        log_level: int = logging.DEBUG,
+        log_level_result: Optional[int] = None,
+        log_level_fail: Optional[int] = None,
+        log_lineoutput: Union[bool, int] = False,
+        check_success: Optional[
+            Union[Callable[[Result], bool], Callable[[BinResult], bool]]
+        ] = None,
+        die_on_error: bool = False,
+        decode_errors: Optional[str] = None,
+    ) -> Union[Result, BinResult]:
+        log_id = _unique_log_id()
+
+        if sudo is None:
+            sudo = self._sudo
+
+        real_cmd, real_env, real_cwd = self._prepare_run(
+            sudo=sudo,
+            cwd=cwd,
+            cmd=cmd,
+            env=env,
+        )
+
+        if log_level >= 0:
+            logger.log(
+                log_level,
+                f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: call {_cmd_to_logstr(real_cmd)}",
+            )
+
+        if isinstance(log_lineoutput, bool):
+            if not log_lineoutput:
+                log_lineoutput = -1
+            elif log_level >= 0:
+                log_lineoutput = log_level
+            else:
+                log_lineoutput = logging.DEBUG
+
+        _handle_line: Optional[Callable[[bool, bytes], None]] = None
+        if log_lineoutput >= 0:
+            line_num = [0, 0]
+
+            def _handle_line_log(is_stdout: bool, line: bytes) -> None:
+                outtype = "stdout" if is_stdout else "stderr"
+                logger.log(
+                    log_lineoutput,
+                    f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: {outtype}[{line_num[is_stdout]}] {repr(line)}",
+                )
+                line_num[is_stdout] += 1
+
+            _handle_line = _handle_line_log
+
+        bin_result = self._run(
+            cmd=real_cmd,
+            env=real_env,
+            cwd=real_cwd,
+            handle_line=_handle_line,
+        )
+
+        # The remainder is only concerned with printing a nice logging message and
+        # (potentially) decode the binary output.
+
+        str_result: Optional[Result] = None
+        unexpected_binary = False
+        is_binary = True
+        decode_exception: Optional[Exception] = None
+        if text:
+            # The caller requested string (Result) output. "decode_errors" control what we do.
+            #
+            # - None (the default). We effectively use "errors='replace'"). On any encoding
+            #   error we log an ERROR message.
+            # - otherwise, we use "decode_errors" as requested. An encoding error will not
+            #   raise the log level, but we will always log the result. We will even log
+            #   the result if the decoding results in an exception (see decode_exception).
+            try:
+                # We first always try to decode strictly to find out whether
+                # it's valid utf-8.
+                str_result = bin_result.decode(errors="strict")
+            except UnicodeError as e:
+                if decode_errors == "strict":
+                    decode_exception = e
+                is_binary = True
+            else:
+                is_binary = False
+
+            if decode_exception is not None:
+                # We had an error. We keep this and re-raise later.
+                pass
+            elif not is_binary and (
+                decode_errors is None
+                or decode_errors in ("strict", "ignore", "replace", "surrogateescape")
+            ):
+                # We are good. The output is not binary, and the caller did not
+                # request some unusual decoding. We already did the decoding.
+                pass
+            elif decode_errors is not None:
+                # Decode again, this time with the decoding option requested
+                # by the caller.
+                try:
+                    str_result = bin_result.decode(errors=decode_errors)
+                except UnicodeError as e:
+                    decode_exception = e
+            else:
+                # We have a binary and the caller didn't specify a special
+                # encoding. We use "replace" fallback, but set a flag that
+                # we have unexpected_binary (and lot an ERROR below).
+                str_result = bin_result.decode(errors="replace")
+                unexpected_binary = True
+
+        if check_success is None:
+            result_success = bin_result.success
+        else:
+            result_success = True
+            if text:
+                str_check = typing.cast(Callable[[Result], bool], check_success)
+                if str_result is None:
+                    # This can only happen in text mode when the caller specified
+                    # a "decode_errors" that resulted in a "decode_exception".
+                    # The function will raise an exception, and we won't call
+                    # the check_success() handler.
+                    #
+                    # Avoid this by using text=False or a "decode_errors" value
+                    # that does not fail.
+                    result_success = False
+                elif not str_check(str_result):
+                    result_success = False
+            else:
+                bin_check = typing.cast(Callable[[BinResult], bool], check_success)
+                if not bin_check(bin_result):
+                    result_success = False
+
+        status_msg = ""
+        if log_level_fail is not None and not result_success:
+            result_log_level = log_level_fail
+        elif log_level_result is not None:
+            result_log_level = log_level_result
+        else:
+            result_log_level = log_level
+
+        if die_on_error and not result_success:
+            if result_log_level < logging.ERROR:
+                result_log_level = logging.ERROR
+            status_msg += " [FATAL]"
+
+        if text and is_binary:
+            status_msg += " [BINARY]"
+
+        if decode_exception:
+            # We caught an exception during decoding. We still want to log the result,
+            # before re-raising the exception.
+            #
+            # We don't increase the logging level, because the user requested a special
+            # "decode_errors". A decoding error is expected, we just want to log about it
+            # (with the level we would have).
+            status_msg += " [DECODE_ERROR]"
+
+        if unexpected_binary:
+            status_msg += " [UNEXPECTED_BINARY]"
+            if result_log_level < logging.ERROR:
+                result_log_level = logging.ERROR
+
+        if str_result is not None:
+            str_result = str_result.dup_with_forced_success(result_success)
+        bin_result = bin_result.dup_with_forced_success(result_success)
+
+        if result_log_level >= 0:
+            if is_binary:
+                # Note that we log the output as binary if either "text=False" or if
+                # the output was not valid utf-8. In the latter case, we will still
+                # return a string Result (or re-raise decode_exception).
+                debug_str = bin_result.debug_str(with_output=log_lineoutput < 0)
+            else:
+                assert str_result is not None
+                debug_str = str_result.debug_str(with_output=log_lineoutput < 0)
+
+            logger.log(
+                result_log_level,
+                f"{log_prefix}cmd[{log_id};{self.pretty_str()}]: └──> {_cmd_to_logstr(real_cmd)}:{status_msg} {debug_str}",
+            )
+
+        if decode_exception:
+            raise decode_exception
+
+        if die_on_error and not result_success:
+            import traceback
+
+            logger.error(
+                f"FATAL ERROR. BACKTRACE:\n{''.join(traceback.format_stack())}"
+            )
+            sys.exit(-1)
+
+        if str_result is not None:
+            return str_result
+        return bin_result
+
+    @abstractmethod
+    def _run(
+        self,
+        *,
+        cmd: Union[str, tuple[str, ...]],
+        env: Optional[dict[str, Optional[str]]],
+        cwd: Optional[str],
+        handle_line: Optional[Callable[[bool, bytes], None]],
+    ) -> BinResult:
+        pass
+
+    def file_exists(self, path: Union[str, os.PathLike[Any]]) -> bool:
+        return self.run(["test", "-e", str(path)], log_level=-1, text=False).success
+
+
+class LocalHost(Host):
+    def pretty_str(self) -> str:
+        return "localhost"
+
+    def _run(
+        self,
+        *,
+        cmd: Union[str, tuple[str, ...]],
+        env: Optional[dict[str, Optional[str]]],
+        cwd: Optional[str],
+        handle_line: Optional[Callable[[bool, bytes], None]],
+    ) -> BinResult:
+        full_env: Optional[dict[str, str]] = None
+        if env is not None:
+            full_env = os.environ.copy()
+            for k, v in env.items():
+                if v is None:
+                    full_env.pop(k, None)
+                else:
+                    full_env[k] = v
+
+        try:
+            pr = subprocess.Popen(
+                cmd,
+                shell=isinstance(cmd, str),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=False,
+                env=full_env,
+                cwd=cwd,
+            )
+        except Exception as e:
+            # We get an FileNotFoundError if cwd directory does not exist or if
+            # the binary does not exist (with shell=False). We get a PermissionError
+            # if we don't have permissions.
+            #
+            # Generally, we don't want to report errors via exceptions, because
+            # you won't get the same exception with shell=True. Instead, we
+            # only report errors via BinResult().
+            #
+            # Usually we avoid creating an artificial BinResult. In this case
+            # there is no choice.
+            return BinResult.internal_failure(str(e))
+
+        buffers = (bytearray(), bytearray())
+
+        def _readlines(
+            stream: Optional[typing.IO[bytes]],
+            *,
+            read_all: bool,
+        ) -> None:
+            assert stream is not None
+            if stream is pr.stdout:
+                is_stdout = True
+            else:
+                assert stream is pr.stderr
+                is_stdout = False
+            while True:
+                b = stream.readline()
+                if not b:
+                    return
+                buffers[is_stdout].extend(b)
+                if handle_line is not None:
+                    handle_line(is_stdout, b)
+                if not read_all:
+                    return
+
+        while True:
+            to_read, _, _ = select.select([pr.stdout, pr.stderr], [], [])
+            for stream in to_read:
+                _readlines(stream, read_all=False)
+            if pr.poll() is not None:
+                break
+        _readlines(pr.stdout, read_all=True)
+        _readlines(pr.stderr, read_all=True)
+        pr.wait()
+
+        return BinResult(bytes(buffers[True]), bytes(buffers[False]), pr.returncode)
+
+    def file_exists(self, path: Union[str, os.PathLike[Any]]) -> bool:
+        return os.path.exists(path)
+
+
+@dataclass(frozen=True)
+class _Login(ABC):
+    user: str
+
+    @abstractmethod
+    def _login(self, client: "paramiko.SSHClient", host: str) -> None:
+        pass
+
+
+@dataclass(frozen=True, **KW_ONLY_DATACLASS)
+class AutoLogin(_Login):
+    def _login(self, client: "paramiko.SSHClient", host: str) -> None:
+        client.connect(
+            host,
+            username=self.user,
+            look_for_keys=True,
+            allow_agent=True,
+        )
+
+
+class RemoteHost(Host):
+    def __init__(
+        self,
+        host: str,
+        *logins: _Login,
+        sudo: bool = False,
+        login_retry_duration: float = 10 * 60,
+    ) -> None:
+        import paramiko
+
+        super().__init__(sudo=sudo)
+        self.host = host
+        self.logins = tuple(logins)
+        self.login_retry_duration = login_retry_duration
+        self._paramiko = paramiko
+        self._tlocal = threading.local()
+
+    def pretty_str(self) -> str:
+        return f"@{self.host}"
+
+    def _prepare_run(
+        self,
+        *,
+        sudo: bool,
+        cwd: Optional[str],
+        cmd: Union[str, Iterable[str]],
+        env: Optional[Mapping[str, Optional[str]]],
+    ) -> tuple[
+        Union[str, tuple[str, ...]],
+        Optional[dict[str, Optional[str]]],
+        Optional[str],
+    ]:
+        cmd, env, cwd = super()._prepare_run(
+            sudo=sudo,
+            cwd=cwd,
+            cmd=cmd,
+            env=env,
+        )
+
+        cmd = _cmd_to_shell(cmd, cwd=cwd)
+
+        if env:
+            # Assume we have a POSIX shell, and we can define variables via `export VAR=...`.
+            cmd2 = ""
+            for k, v in env.items():
+                assert k == shlex.quote(k)
+                if v is None:
+                    cmd2 += f"unset  -v {k} ; "
+                else:
+                    cmd2 += f"export {k}={shlex.quote(v)} ; "
+            cmd = cmd2 + cmd
+
+        return cmd, None, None
+
+    def _get_client(
+        self,
+    ) -> tuple[threading.local, "paramiko.SSHClient", Optional[_Login]]:
+        tlocal = self._tlocal
+        client = getattr(tlocal, "client", None)
+        login: Optional[_Login] = None
+        if client is None:
+            client = self._paramiko.SSHClient()
+            client.set_missing_host_key_policy(self._paramiko.AutoAddPolicy())
+            tlocal.client = client
+            tlocal.login = None
+        else:
+            login = tlocal.login
+        return tlocal, client, login
+
+    def _ensure_login(
+        self,
+        *,
+        force_new_login: bool = False,
+        start_timestamp: float = -1.0,
+    ) -> tuple[Optional["paramiko.SSHClient"], bool]:
+        tlocal, client, login = self._get_client()
+
+        if login is not None:
+            if not force_new_login:
+                return client, False
+
+        if start_timestamp == -1.0:
+            start_timestamp = time.monotonic()
+
+        end_timestamp = start_timestamp + self.login_retry_duration
+
+        tlocal.login = None
+
+        try_count = 0
+
+        while True:
+            for login in self.logins:
+                try:
+                    login._login(client, self.host)
+                except Exception as e:
+                    error = e
+                else:
+                    tlocal.login = login
+                    logger.debug(
+                        f"remote[{self.pretty_str()}]: successfully logged in to {login}"
+                    )
+                    return client, True
+
+                if try_count == 0:
+                    logger.debug(
+                        f"remote[{self.pretty_str()}]: failed to login to {login}: {error}"
+                    )
+
+            try_count += 1
+
+            if time.monotonic() >= end_timestamp:
+                logger.debug(
+                    f"remote[{self.pretty_str()}]: failed to login with credentials {self.logins} ({try_count} tries)"
+                )
+                return None, False
+
+    def _run(
+        self,
+        *,
+        cmd: Union[str, tuple[str, ...]],
+        env: Optional[dict[str, Optional[str]]],
+        cwd: Optional[str],
+        handle_line: Optional[Callable[[bool, bytes], None]],
+    ) -> BinResult:
+
+        assert isinstance(cmd, str)
+        assert env is None
+        assert cwd is None
+
+        bin_cmd: Any = cmd.encode("utf-8", errors="surrogateescape")
+
+        start_timestamp = time.monotonic()
+        first_try = True
+        while True:
+            client, new_login = self._ensure_login(
+                start_timestamp=start_timestamp,
+                force_new_login=not first_try,
+            )
+            if client is None:
+                return BinResult.internal_failure(
+                    f"failed to login to remote host {self.host}"
+                )
+
+            try:
+                _, stdout, stderr = client.exec_command(bin_cmd)
+            except Exception as e:
+                if new_login:
+                    # We just did a new login and got a failure. Propagate the
+                    # error.
+                    return BinResult.internal_failure(str(e))
+
+                # We had a cached login from earlier. Maybe this was broken
+                # and the cause for error now. Retry and force new login.
+                first_try = False
+                continue
+
+            break
+
+        buffers = (bytearray(), bytearray())
+        sources = (stderr, stdout)
+        fds = tuple(s.channel.fileno() for s in sources)
+
+        for source in sources:
+            source.channel.setblocking(0)
+
+        def _readlines(*, is_stdout: bool) -> None:
+            channel = sources[is_stdout].channel
+            buffer = buffers[is_stdout]
+            start_idx = len(buffer)
+            while True:
+                try:
+                    if is_stdout:
+                        d = channel.recv(32768)
+                    else:
+                        d = channel.recv_stderr(32768)
+                except Exception:
+                    d = b""
+                if not d:
+                    break
+                buffer.extend(d)
+
+            if start_idx == len(buffer):
+                return
+
+            if handle_line is not None:
+                while True:
+                    idx = buffer.find(b"\n", start_idx)
+                    if idx != -1:
+                        line = bytes(buffer[start_idx : idx + 1])
+                        start_idx = idx + 1
+                    elif start_idx < len(buffer):
+                        line = bytes(buffer[start_idx:])
+                        start_idx = len(buffer)
+                    else:
+                        break
+                    handle_line(is_stdout, line)
+
+        while not stdout.channel.exit_status_ready():
+            to_read, _, _ = select.select(fds, [], [])
+            for fd in to_read:
+                _readlines(is_stdout=(fd == fds[True]))
+        returncode = stdout.channel.recv_exit_status()
+        _readlines(is_stdout=True)
+        _readlines(is_stdout=False)
+
+        return BinResult(bytes(buffers[True]), bytes(buffers[False]), returncode)
+
+
+local = LocalHost()
+
+
+def host_or_local(host: Optional[Host]) -> Host:
+    if host is None:
+        return local
+    return host
+
+
+if typing.TYPE_CHECKING:
+    import paramiko

--- a/ktoolbox/k8sClient.py
+++ b/ktoolbox/k8sClient.py
@@ -1,0 +1,201 @@
+import json
+import logging
+import os
+import random
+import shlex
+import sys
+import typing
+import yaml
+
+from collections.abc import Iterable
+from typing import Union
+
+from . import host
+from .logger import logger
+
+
+class K8sClient:
+    def __init__(self, kubeconfig: typing.Optional[str] = None):
+        if kubeconfig is None:
+            kubeconfig = os.getenv("KUBECONFIG")
+            if not kubeconfig:
+                raise RuntimeError(
+                    "KUBECONFIG environment variable not set and no kubeconfig argument specified"
+                )
+
+        if not os.path.exists(kubeconfig):
+            raise RuntimeError(
+                f"KUBECONFIG={shlex.quote(kubeconfig)} file does not exist"
+            )
+        # Load the file to check that it is valid YAML.
+        with open(kubeconfig) as f:
+            yaml.safe_load(f)
+
+        self.kubeconfig = kubeconfig
+
+    @staticmethod
+    def _get_oc_cmd(cmd: Union[str, Iterable[str]]) -> list[str]:
+        if isinstance(cmd, str):
+            return shlex.split(cmd)
+        return list(cmd)
+
+    def _get_oc_cmd_full(
+        self,
+        *,
+        cmd: Union[str, Iterable[str]],
+        namespace: typing.Optional[str] = None,
+    ) -> list[str]:
+        namespace_args: tuple[str, ...]
+        if namespace:
+            namespace_args = ("-n", namespace)
+        else:
+            namespace_args = ()
+        return [
+            "kubectl",
+            "--kubeconfig",
+            self.kubeconfig,
+            *namespace_args,
+            *self._get_oc_cmd(cmd),
+        ]
+
+    def oc(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        check_success: typing.Optional[typing.Callable[[host.Result], bool]] = None,
+        namespace: typing.Optional[str] = None,
+    ) -> host.Result:
+        return host.local.run(
+            self._get_oc_cmd_full(cmd=cmd, namespace=namespace),
+            die_on_error=die_on_error,
+            check_success=check_success,
+            log_level_fail=logging.DEBUG if may_fail else logging.ERROR,
+        )
+
+    def oc_exec(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        pod_name: str,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        namespace: typing.Optional[str] = None,
+    ) -> host.Result:
+        return self.oc(
+            ["exec", pod_name, "--", *self._get_oc_cmd(cmd)],
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+    def oc_get(
+        self,
+        what: str,
+        *,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+        namespace: typing.Optional[str] = None,
+    ) -> typing.Optional[dict[str, typing.Any]]:
+        cmd = ["get", what, "-o", "json"]
+        ret = self.oc(
+            cmd,
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+        if not ret.success:
+            # No need for extra logging in this failure case. self.oc() already
+            # did all the logging we want.
+            return None
+
+        try:
+            data = json.loads(ret.out)
+        except ValueError:
+            data = None
+
+        if not isinstance(data, dict):
+            cmd_s = shlex.join(self._get_oc_cmd_full(cmd=cmd, namespace=namespace))
+            if not may_fail or die_on_error:
+                logger.error(
+                    f"Command {cmd_s} did not return a JSON dictionary but {ret.debug_str()}"
+                )
+            else:
+                logger.debug(f"Command {cmd_s} did not return a JSON dictionary")
+            if die_on_error:
+                sys.exit(-1)
+            return None
+
+        return data
+
+    def oc_debug(
+        self,
+        cmd: Union[str, Iterable[str]],
+        *,
+        node_name: str,
+        test_image: str,
+        namespace: str,
+        may_fail: bool = False,
+        die_on_error: bool = False,
+    ) -> host.Result:
+        container_name = f"ocp-tft-debug-{node_name}-{random.randint(0, 2**64-1):016x}"
+        # We use `kubectl debug` and not `oc debug`. There are thus some differences.
+        #
+        # Optimally, we would use "--profile=sysadmin". But that is too new, so
+        # we cannot use it and have no CAP_SYS_CHROOT.  That means, `cmd`
+        # cannot be `chroot /host crictl ...` but needs to be
+        # `/host/usr/bin/crictl --runtime-endpoint=unix:///host/run/crio/crio.sock ...`.
+        #
+        # Also, unlike `oc debug`, we need an "--image", which the caller must specify.
+        #
+        # Also, we must specify a namespace. And the container will linger around afterwards,
+        # so we need to delete it (below).
+        result = self.oc(
+            [
+                "debug",
+                "-q",
+                "-ti",
+                "--profile=general",
+                f"--container={container_name}",
+                f"--image={test_image}",
+                f"node/{node_name}",
+                "--",
+                *self._get_oc_cmd(cmd),
+            ],
+            may_fail=may_fail,
+            die_on_error=die_on_error,
+            namespace=namespace,
+        )
+
+        # We have to find and delete the pods we just created. As we used
+        # a unique {container_name}, we can search for that.
+        pod_names = []
+        pdict = self.oc_get(
+            "pods",
+            may_fail=True,
+            namespace=namespace,
+        )
+        pdict_items = []
+        if pdict is not None:
+            try:
+                pdict_items = list(pdict["items"])
+            except Exception:
+                pass
+        for pdict_item in pdict_items:
+            try:
+                for c in pdict_item["spec"]["containers"]:
+                    if c["name"] == container_name:
+                        pod_names.append(pdict_item["metadata"]["name"])
+                        break
+            except Exception:
+                pass
+        for pod_name in pod_names:
+            self.oc(
+                ["delete", "--wait=false", f"pod/{pod_name}"],
+                may_fail=True,
+                namespace=namespace,
+            )
+
+        return result

--- a/ktoolbox/logger.py
+++ b/ktoolbox/logger.py
@@ -1,0 +1,28 @@
+import logging
+
+from typing import Optional
+from typing import TextIO
+
+
+def configure_logger(lvl: int) -> None:
+    global logger
+    logger.setLevel(lvl)
+
+    fmt = "%(asctime)s.%(msecs)03d %(levelname)-7s [th:%(thread)s]: %(message)s"
+    datefmt = "%Y-%m-%d %H:%M:%S"
+    formatter = logging.Formatter(fmt, datefmt)
+
+    handler = logging.StreamHandler()
+    handler.setLevel(lvl)
+    handler.setFormatter(formatter)
+
+    global prev_handler
+    if prev_handler is not None:
+        logger.removeHandler(prev_handler)
+    prev_handler = handler
+    logger.addHandler(handler)
+
+
+prev_handler: Optional["logging.StreamHandler[TextIO]"] = None
+logger = logging.getLogger("CDA")
+configure_logger(logging.DEBUG)

--- a/ktoolbox/netdev.py
+++ b/ktoolbox/netdev.py
@@ -1,0 +1,1089 @@
+import json
+import os
+import re
+import socket
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+from typing import Optional
+from typing import Union
+
+from . import host
+from . import common
+
+from .common import strict_dataclass
+from .common import dict_add_optional
+
+
+def _parse_line(line: str, caption: str) -> Optional[str]:
+    if line.startswith(caption):
+        return line[len(caption) :]
+    return None
+
+
+_isspace_kernel_set = {c[0] for c in (b" ", b"\n", b"\t", b"\r", b"\f", b"\v", b"\240")}
+
+
+def isspace_kernel(c: Union[int, bytes]) -> bool:
+    # mirrors kernel's isspace() from "include/linux/ctype.h", which treats as
+    # space the common ASCII spaces, including '\v' (vertical tab), but also
+    # '\240' (non-breaking space, NBSP in Latin-1). */
+    if isinstance(c, int):
+        if c < 0 or c > 255:
+            raise ValueError("Integer is not a valid byte")
+    elif isinstance(c, bytes):
+        if len(c) != 1:
+            raise ValueError("Requires a single byte as argument")
+        c = c[0]
+    else:
+        raise TypeError("Expects either an integer or a single byte")
+
+    return c in _isspace_kernel_set
+
+
+def validate_addr_family(
+    addr_family: Optional[Union[str, int]],
+    *,
+    with_unspec: bool = False,
+) -> int:
+    if addr_family is None:
+        if with_unspec:
+            return socket.AF_UNSPEC
+    elif isinstance(addr_family, int):
+        if addr_family in (socket.AF_INET, socket.AF_INET6):
+            return addr_family
+        if with_unspec:
+            if addr_family == socket.AF_UNSPEC:
+                return addr_family
+    elif isinstance(addr_family, str):
+        af2 = addr_family.lower().strip()
+        if af2 in ("4", "inet", "inet4", "ipv4", "ip4", "addr4"):
+            return socket.AF_INET
+        if af2 in ("6", "inet6", "ipv6", "ip6", "addr6"):
+            return socket.AF_INET6
+        if with_unspec:
+            if af2 in ("", "any", "unspec"):
+                return socket.AF_UNSPEC
+    raise ValueError(f"invalid address family {repr(addr_family)}")
+
+
+def addr_family_to_str(addr_family: Optional[Union[str, int]]) -> str:
+    addr_family = validate_addr_family(addr_family, with_unspec=True)
+    if addr_family == socket.AF_INET:
+        return "IPv4"
+    if addr_family == socket.AF_INET6:
+        return "IPv6"
+    return "IP"
+
+
+def validate_ipaddr(
+    addr: str,
+    *,
+    addr_family: Optional[Union[str, int]] = None,
+) -> tuple[str, int]:
+    addr_orig = addr
+    addr_family = validate_addr_family(addr_family, with_unspec=True)
+
+    addrbin = None
+
+    if isinstance(addr, str):
+        # We accept whitespace. Strip it.
+        addr = addr.strip()
+
+    if addr_family in (socket.AF_INET, socket.AF_UNSPEC):
+        try:
+            addrbin = socket.inet_pton(socket.AF_INET, addr)
+        except socket.error:
+            pass
+        else:
+            addr_family = socket.AF_INET
+
+    if addrbin is None and addr_family in (socket.AF_INET6, socket.AF_UNSPEC):
+        try:
+            addrbin = socket.inet_pton(socket.AF_INET6, addr)
+        except socket.error:
+            pass
+        else:
+            addr_family = socket.AF_INET6
+        if (
+            addrbin is None
+            and isinstance(addr, str)
+            and len(addr) > 2
+            and addr[0] == "["
+            and addr[-1] == "]"
+        ):
+            # Maybe the IPv6 address is wrapped in []. Retry.
+            try:
+                addrbin = socket.inet_pton(socket.AF_INET6, addr[1:][0:-1])
+            except socket.error:
+                pass
+            else:
+                addr_family = socket.AF_INET6
+    if addrbin is None:
+        raise ValueError(
+            f"{repr(addr_orig)} is not a valid {addr_family_to_str(addr_family)} address"
+        )
+
+    addr2 = socket.inet_ntop(addr_family, addrbin)
+    return addr2, addr_family
+
+
+def normalize_ifname(
+    ifname: Union[str, bytes],
+    *,
+    validate: bool = False,
+    allow_reserved: bool = True,
+) -> bytes:
+    if isinstance(ifname, str):
+        ifname = ifname.encode("utf-8", errors="surrogateescape")
+    elif not isinstance(ifname, bytes):
+        raise TypeError(f"Unexpected ifname of type {type(ifname)}")
+
+    if validate:
+        if not ifname:
+            raise ValueError("Ifname cannot be empty")
+        if b"/" in ifname:
+            raise ValueError("Ifname cannot contain slash")
+        if ifname in (b".", b".."):
+            raise ValueError(f'Ifname cannot be "{ifname.decode()}"')
+        if len(ifname) > 15:
+            raise ValueError("Ifname cannot be longer than 15 characters")
+        if b":" in ifname:
+            raise ValueError("Ifname cannot contain colon")
+        for c in ifname:
+            if c == 0:
+                raise ValueError("Invalid zero bytes")
+            if isspace_kernel(c):
+                raise ValueError("Invalid white space")
+        if not allow_reserved:
+            # Certain modules create sysctl files that later prevent creating
+            # interfaces with those names. However, you can create those interfaces
+            # if the module is not loaded.
+            #
+            # You are advised to not use those interface names, but you can
+            # create such interfaces in kernel (if the conflicting module is
+            # not loaded).
+            #
+            # The "all" and "default" names are reserved
+            # due to their directories in "/proc/sys/net/ipv4/conf/" and "/proc/sys/net/ipv6/conf/".
+            # Also, there is "/sys/class/net/bonding_masters" file.
+            if ifname in (
+                b"all",
+                b"default",
+                b"bonding_masters",
+            ):
+                raise ValueError(f"Interface name {repr(ifname)} is reserved")
+
+    return ifname
+
+
+def validate_ifname(
+    ifname: Union[str, bytes],
+    *,
+    allow_reserved: bool = True,
+) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    #
+    # See also, dev_valid_name() in kernel.
+    ifname = normalize_ifname(ifname, validate=True, allow_reserved=allow_reserved)
+    return ifname.decode(errors="surrogateescape")
+
+
+def validate_ifname_or_none(ifname: Union[str, bytes]) -> Optional[str]:
+    try:
+        return validate_ifname(ifname)
+    except ValueError:
+        return None
+
+
+_pciaddr_re = re.compile("^[0-9a-f]{4}:[0-9a-f]{2}:[01][0-9a-f].[0-7]$")
+
+
+def validate_pciaddr(pciaddr: Union[str, bytes]) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    if isinstance(pciaddr, bytes):
+        try:
+            pciaddr = pciaddr.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError(
+                f"PCI address cannot contain non UTF-8 characters ({repr(pciaddr)})"
+            )
+    elif not isinstance(pciaddr, str):
+        raise TypeError(f"PCI address of unexpected type {type(pciaddr)}")
+    if not pciaddr:
+        raise ValueError("PCI address cannot be empty")
+    if not _pciaddr_re.search(pciaddr):
+        raise ValueError(f"PCI address contains invalid characters ({repr(pciaddr)})")
+    if pciaddr in (".", ".."):
+        raise ValueError(f'PCI address cannot be "{pciaddr}"')
+    return pciaddr
+
+
+_ethaddr_re = re.compile(
+    "^([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?):([0-9a-fA-F][0-9a-fA-F]?)$"
+)
+
+
+def validate_ethaddr(ethaddr: Union[str, bytes]) -> str:
+    # The main point of this validation is whether this can be used
+    # safely in a path name.
+    if isinstance(ethaddr, bytes):
+        try:
+            ethaddr = ethaddr.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError(
+                f"Ethernet address cannot contain non UTF-8 characters ({repr(ethaddr)})"
+            )
+    elif not isinstance(ethaddr, str):
+        raise TypeError(f"Ethernet address of unexpected type {type(ethaddr)}")
+    m = _ethaddr_re.search(ethaddr)
+    if not m:
+        raise ValueError(
+            f"Ethernet address contains invalid characters ({repr(ethaddr)})"
+        )
+
+    def _normalize_hex(s: str) -> str:
+        s = s.lower()
+        if len(s) == 1:
+            return "0" + s
+        return s
+
+    ethaddr2 = ":".join(_normalize_hex(m.group(i)) for i in range(1, 7))
+    if ethaddr2 == ethaddr:
+        return ethaddr
+    return ethaddr2
+
+
+def validate_ethaddr_or_none(ethaddr: Union[str, bytes]) -> Optional[str]:
+    try:
+        return validate_ethaddr(ethaddr)
+    except ValueError:
+        return None
+
+
+def pciaddr_get_func_address(pciaddr: Optional[Union[str, bytes]]) -> Optional[int]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/master/sriovnet_switchdev.go#L172
+    if pciaddr is None:
+        return None
+
+    pciaddr = validate_pciaddr(pciaddr)
+
+    last_char = pciaddr[-1]
+    return int(last_char)
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class IPRouteAddressInfoEntry:
+    family: str
+    local: str
+
+    def _post_check(self) -> None:
+        if not isinstance(self.family, str) or self.family not in ("inet", "inet6"):
+            raise ValueError("Invalid address family")
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class IPRouteAddressEntry:
+    ifindex: int
+    ifname: str
+    flags: tuple[str, ...]
+    master: Optional[str]
+    address: str  # Ethernet address.
+    addr_info: tuple[IPRouteAddressInfoEntry, ...]
+
+    def has_carrier(self) -> bool:
+        return "NO-CARRIER" not in self.flags
+
+
+def ip_addrs_parse(
+    jstr: str,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+) -> list[IPRouteAddressEntry]:
+    ret: list[IPRouteAddressEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+            entry = IPRouteAddressEntry(
+                ifindex=e["ifindex"],
+                ifname=validate_ifname(e["ifname"]),
+                flags=tuple(e["flags"]),
+                master=e["master"] if "master" in e else None,
+                address=e["address"],
+                addr_info=tuple(
+                    IPRouteAddressInfoEntry(
+                        family=addr["family"],
+                        local=addr["local"],
+                    )
+                    for addr in e["addr_info"]
+                ),
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        if ifname is not None and normalize_ifname(ifname) != normalize_ifname(
+            entry.ifname
+        ):
+            continue
+        ret.append(entry)
+    return ret
+
+
+def ip_addrs(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+    ip_log_level: int = -1,
+) -> list[IPRouteAddressEntry]:
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json addr",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-route on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_addrs_parse(ret.out, strict_parsing=strict_parsing, ifname=ifname)
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class IPRouteLinkEntry:
+    ifindex: int
+    ifname: str
+    address: Optional[str]
+    permaddr: Optional[str]
+    flags: tuple[str, ...]
+    mtu: int
+    operstate: str
+    link_info_kind: Optional[str]
+
+    def match_ifname(self, ifname: Optional[Union[str, bytes]]) -> bool:
+        if ifname is None:
+            return False
+        return normalize_ifname(self.ifname) == normalize_ifname(ifname)
+
+
+def ip_links_parse(
+    jstr: str, *, strict_parsing: bool = False, ifname: Optional[str] = None
+) -> list[IPRouteLinkEntry]:
+    ret: list[IPRouteLinkEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+
+            link_info_kind: Optional[str] = None
+            link_info = e.get("linkinfo")
+            if link_info is not None:
+                link_info_kind = link_info.get("info_kind")
+
+            address = e.get("address")
+            if address is not None:
+                address = validate_ethaddr_or_none(address)
+
+            permaddr = e.get("permaddr")
+            if permaddr is not None:
+                permaddr = validate_ethaddr_or_none(permaddr)
+
+            entry = IPRouteLinkEntry(
+                ifindex=e["ifindex"],
+                ifname=validate_ifname(e["ifname"]),
+                mtu=int(e["mtu"]),
+                flags=tuple(e["flags"]),
+                operstate=(e["operstate"]),
+                link_info_kind=link_info_kind,
+                address=address,
+                permaddr=permaddr,
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        if ifname is not None and normalize_ifname(ifname) != normalize_ifname(
+            entry.ifname
+        ):
+            continue
+        ret.append(entry)
+    return ret
+
+
+def ip_links(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ifname: Optional[str] = None,
+    ip_log_level: int = -1,
+) -> list[IPRouteLinkEntry]:
+    # If @ifname is requested, we could issue a `ip -json link show $IFNAME`. However,
+    # that means we do different things for requesting one link vs. all links. That
+    # seems undesirable. Instead, in all cases fetch all links. Any filtering then happens
+    # in code that we control. Performance should not make a difference, since the JSON data
+    # is probably small anyway (compared to the overhead of invoking a shell command).
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json -d link",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-link on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_links_parse(ret.out, strict_parsing=strict_parsing, ifname=ifname)
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class IPRouteRouteEntry:
+    dst: str
+    dev: str
+
+
+def ip_routes_parse(
+    jstr: str,
+    *,
+    strict_parsing: bool = False,
+) -> list[IPRouteRouteEntry]:
+    ret: list[IPRouteRouteEntry] = []
+    for e in common.json_parse_list(jstr, strict_parsing=strict_parsing):
+        try:
+            entry = IPRouteRouteEntry(
+                dst=e["dst"],
+                dev=validate_ifname(e["dev"]),
+            )
+        except (KeyError, ValueError, TypeError):
+            if strict_parsing:
+                raise
+            continue
+
+        ret.append(entry)
+    return ret
+
+
+def ip_routes(
+    rsh: Optional[host.Host] = None,
+    *,
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> list[IPRouteRouteEntry]:
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        "ip -json route",
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ip-route on {rsh.pretty_str()} failed ({ret})")
+        return []
+
+    return ip_routes_parse(ret.out, strict_parsing=strict_parsing)
+
+
+def ethtool_permaddr(
+    rsh: Optional[host.Host] = None,
+    *,
+    ifname: Union[str, bytes],
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> Optional[str]:
+    ifname = validate_ifname(ifname)
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        ["ethtool", "-P", ifname],
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+        env={"LANG": "C"},
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ethtool -P {repr(ifname)} failed ({ret})")
+        return None
+
+    permaddr: Optional[str] = None
+
+    for line in ret.out.splitlines():
+        if (x := _parse_line(line, "Permanent address: ")) is not None:
+            permaddr = x
+
+    if permaddr is None:
+        return None
+
+    return validate_ethaddr_or_none(permaddr)
+
+
+@strict_dataclass
+@dataclass(frozen=True, **common.KW_ONLY_DATACLASS)
+class EthtoolDriverInfo:
+    ifname: str
+    driver: Optional[str]
+    version: Optional[str]
+    firmware_version: Optional[str]
+
+
+def ethtool_driver(
+    rsh: Optional[host.Host] = None,
+    *,
+    ifname: Union[str, bytes],
+    strict_parsing: bool = False,
+    ip_log_level: int = -1,
+) -> Optional[EthtoolDriverInfo]:
+    ifname = validate_ifname(ifname)
+    rsh = host.host_or_local(rsh)
+    ret = rsh.run(
+        ["ethtool", "-i", ifname],
+        decode_errors="surrogateescape",
+        log_level=ip_log_level,
+        env={"LANG": "C"},
+    )
+    if not ret.success:
+        if strict_parsing:
+            raise RuntimeError(f"calling ethtool -i {repr(ifname)} failed ({ret})")
+        return None
+
+    driver: Optional[str] = None
+    version: Optional[str] = None
+    firmware_version: Optional[str] = None
+
+    for line in ret.out.splitlines():
+        if (x := _parse_line(line, "driver: ")) is not None:
+            driver = x
+        elif (x := _parse_line(line, "version: ")) is not None:
+            version = x
+        elif (x := _parse_line(line, "firmware-version: ")) is not None:
+            firmware_version = x
+
+    return EthtoolDriverInfo(
+        ifname=ifname,
+        driver=driver,
+        version=version,
+        firmware_version=firmware_version,
+    )
+
+
+def _sysctl_parse_str(s: Optional[Union[str, bytes]]) -> Optional[str]:
+    if s is None:
+        return None
+
+    if isinstance(s, bytes):
+        try:
+            s = s.decode("utf-8", errors="strict")
+        except UnicodeDecodeError:
+            return None
+
+    if not isinstance(s, str):
+        return None
+
+    return s.strip()
+
+
+def sysctl_read(
+    path: Union[str, bytes],
+    *,
+    strip: bool = True,
+    fail_on_error: bool = False,
+) -> Optional[str]:
+
+    try:
+        with open(path, "rb") as f:
+            data = f.read()
+    except Exception:
+        if fail_on_error:
+            raise
+        return None
+
+    # We always return a `str`, but invalid characters are escaped
+    # via "surrogateescape". Depending on what you need to do, you
+    # may need to consider that.
+    s = data.decode("utf-8", errors="surrogateescape")
+    if strip:
+        s = s.strip()
+    return s
+
+
+def sysctl_phys_port_name_parse(
+    s: Optional[Union[str, bytes]]
+) -> Optional[tuple[int, int]]:
+    # Parses the output of /sys/class/net/$IFNAME/phys_port_name
+    #
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L84C6-L84C19
+
+    s = _sysctl_parse_str(s)
+    if s is None:
+        return None
+
+    m = re.search("^(c[0-9]+)?pf([0-9]+)vf([0-9]+)$", s)
+    if m:
+        try:
+            return (int(m.group(2)), int(m.group(3)))
+        except Exception:
+            pass
+
+    # old kernel syntax of phys_port_name is vf index
+    m = re.search("^[0-9]+$", s)
+    if m:
+        try:
+            return (0, int(m.group()))
+        except Exception:
+            pass
+
+    return None
+
+
+def get_phys_port_name(ifname: Union[str, bytes]) -> Optional[str]:
+    return sysctl_read(f"/sys/class/net/{validate_ifname(ifname)}/phys_port_name")
+
+
+def get_phys_switch_id(ifname: Union[str, bytes]) -> Optional[str]:
+    return sysctl_read(f"/sys/class/net/{validate_ifname(ifname)}/phys_switch_id")
+
+
+def get_ifnames() -> list[str]:
+    try:
+        ifs1 = os.listdir(b"/sys/class/net/")
+    except Exception:
+        return []
+
+    def _validate(ifname: bytes) -> Optional[str]:
+        if not os.path.islink(b"/sys/class/net/" + ifname):
+            return None
+        return validate_ifname_or_none(ifname)
+
+    return sorted(common.iter_filter_none(_validate(i) for i in ifs1))
+
+
+def get_pciaddrs() -> list[str]:
+    path = "/sys/bus/pci/devices/"
+    pcis = os.listdir(path)
+    pcis = [validate_pciaddr(p) for p in pcis if os.path.exists(path + p + "/net/")]
+    pcis2 = dict.fromkeys(pcis)
+    return list(pcis2)
+
+
+def _get_pciaddr_from_path(path: str) -> Optional[str]:
+    i = path.rfind("/")
+    if i >= 0:
+        pciaddr = path[i + 1 :]
+    else:
+        pciaddr = path
+    try:
+        return validate_pciaddr(pciaddr)
+    except Exception:
+        return None
+
+
+def _get_usbaddr_from_path(path: str) -> Optional[str]:
+    i = path.rfind("/")
+    if i >= 0:
+        usbaddr = path[i + 1 :]
+    else:
+        usbaddr = path
+    if not re.search("^[-0-9a-f.:]+$", usbaddr):
+        return None
+    return usbaddr
+
+
+def get_busaddr_from_ifname(ifname: Union[str, bytes]) -> Optional[tuple[str, str]]:
+    ifname = validate_ifname(ifname)
+    try:
+        path = os.readlink(f"/sys/class/net/{ifname}/device")
+    except Exception:
+        return None
+
+    pciaddr = _get_pciaddr_from_path(path)
+    if pciaddr is not None and os.path.exists(f"/sys/bus/pci/devices/{pciaddr}"):
+        return ("pci", pciaddr)
+
+    usbaddr = _get_usbaddr_from_path(path)
+    if usbaddr is not None and os.path.exists(f"/sys/bus/usb/devices/{usbaddr}"):
+        return ("usb", usbaddr)
+
+    return None
+
+
+def get_pciaddr_from_ifname(ifname: Union[str, bytes]) -> Optional[str]:
+    busaddr = get_busaddr_from_ifname(ifname)
+    if busaddr is None:
+        return None
+    bustype, busaddress = busaddr
+    if bustype != "pci":
+        return None
+    return busaddress
+
+
+def _get_ifnames_from_dir(dirname: str) -> Optional[list[str]]:
+    try:
+        devices = os.listdir(dirname)
+    except Exception:
+        return None
+    return sorted(common.iter_filter_none(validate_ifname_or_none(d) for d in devices))
+
+
+def get_ifnames_from_pciaddr(pciaddr: str) -> Optional[list[str]]:
+    return _get_ifnames_from_dir(
+        f"/sys/bus/pci/devices/{validate_pciaddr(pciaddr)}/net/"
+    )
+
+
+def get_ifindex_from_ifname(ifname: Union[str, bytes]) -> Optional[int]:
+    ifname = validate_ifname(ifname)
+    try:
+        v = sysctl_read(f"/sys/class/net/{ifname}/ifindex")
+    except Exception:
+        pass
+    else:
+        if v:
+            try:
+                return int(v)
+            except Exception:
+                pass
+    return None
+
+
+def get_address_from_ifname(ifname: Union[str, bytes]) -> Optional[str]:
+    ifname = validate_ifname(ifname)
+    try:
+        data = sysctl_read(f"/sys/class/net/{ifname}/address")
+        if data:
+            return validate_ethaddr(data)
+    except Exception:
+        pass
+    return None
+
+
+def is_switchdev(ifname: Union[str, bytes]) -> bool:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L102
+    return bool(get_phys_switch_id(ifname))
+
+
+def get_uplink_representor(pciaddr: str) -> Optional[str]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L116
+    pciaddr = validate_pciaddr(pciaddr)
+
+    devicePath = f"/sys/bus/pci/devices/{pciaddr}/physfn/net"
+    if not os.path.exists(devicePath):
+        devicePath = f"/sys/bus/pci/devices/{pciaddr}/net"
+        if not os.path.exists(devicePath):
+            return None
+
+    devices = _get_ifnames_from_dir(devicePath)
+    for device in devices or ():
+        if not is_switchdev(device):
+            continue
+        # Try to get the phys port name, if not exists then fallback to check without it
+        # phys_port_name should be in formant p<port-num> e.g p0,p1,p2 ...etc.
+        port_name = get_phys_port_name(device)
+        if port_name is not None:
+            if not re.search("^p[0-9]+$", port_name):
+                continue
+        return device
+
+    return None
+
+
+def get_vf_representor(
+    uplink_ifname: Union[str, bytes], vf_index: int
+) -> Optional[str]:
+    # https://github.com/k8snetworkplumbingwg/sriovnet/blob/3ca5e43034e6425fb5e4b0b4d3c8c3a2b3f5a5e8/sriovnet_switchdev.go#L143
+    uplink_ifname = validate_ifname(uplink_ifname)
+
+    phys_switch_id = get_phys_switch_id(uplink_ifname)
+    if phys_switch_id is None:
+        return None
+
+    uplink_pciaddr = get_pciaddr_from_ifname(uplink_ifname)
+    uplink_pci_func_address = pciaddr_get_func_address(uplink_pciaddr)
+
+    devices = _get_ifnames_from_dir(f"/sys/class/net/{uplink_ifname}/subsystem")
+    for device in devices or ():
+        device_switch_id = get_phys_switch_id(device)
+        if device_switch_id != phys_switch_id:
+            continue
+        port_name = sysctl_phys_port_name_parse(get_phys_port_name(device))
+        if port_name is None:
+            continue
+        if port_name[0] != uplink_pci_func_address:
+            continue
+        if port_name[1] != vf_index:
+            continue
+
+        return device
+
+    return None
+
+
+def get_vfs_for_representor(uplink_pciaddr: str) -> list[tuple[str, int]]:
+    uplink_pciaddr = validate_pciaddr(uplink_pciaddr)
+
+    path = f"/sys/bus/pci/devices/{uplink_pciaddr}"
+
+    try:
+        files = os.listdir(path)
+    except Exception:
+        return []
+
+    result: list[tuple[str, int]] = []
+
+    regex = re.compile("^virtfn(\\d+)$")
+
+    for file in files:
+        m = regex.search(file)
+        if not m:
+            continue
+
+        try:
+            vf_index = int(m.group(1))
+        except Exception:
+            continue
+
+        try:
+            data = os.readlink(f"{path}/{file}")
+        except Exception:
+            continue
+        pciaddr = _get_pciaddr_from_path(data)
+
+        if pciaddr is None:
+            continue
+
+        result.append((pciaddr, vf_index))
+
+    return result
+
+
+@common.repeat_for_same_result
+def get_device_infos(with_ethtool: bool = True) -> list[dict[str, Any]]:
+
+    result = []
+
+    devices: set[tuple[Optional[str], Optional[str]]] = set()
+
+    link_infos: dict[str, Optional[IPRouteLinkEntry]]
+    link_infos = dict.fromkeys(get_ifnames())
+    link_infos.update((lnk.ifname, lnk) for lnk in ip_links())
+
+    ifnames_tmp = set(link_infos)
+    for pciaddr1 in get_pciaddrs():
+        ifnames1 = get_ifnames_from_pciaddr(pciaddr1)
+        if ifnames1:
+            for ifname1 in ifnames1:
+                devices.add((pciaddr1, ifname1))
+                ifnames_tmp.discard(ifname1)
+        else:
+            devices.add((pciaddr1, None))
+    for ifname1 in ifnames_tmp:
+        devices.add((None, ifname1))
+
+    for device in devices:
+        res: dict[str, Any] = {}
+
+        pciaddr, ifname = device
+
+        if ifname is not None:
+            link_info = link_infos.get(ifname)
+            if link_info is not None:
+                res["ifindex"] = link_info.ifindex
+            else:
+                dict_add_optional(res, "ifindex", get_ifindex_from_ifname(ifname))
+        else:
+            link_info = None
+
+        if ifname is not None:
+            res["ifname"] = ifname
+
+        if pciaddr is not None:
+            res["pciaddr"] = pciaddr
+        elif ifname is not None:
+            busaddr = get_busaddr_from_ifname(ifname)
+            if busaddr is not None:
+                bustype, busaddress = busaddr
+                if bustype == "usb":
+                    res["usbaddr"] = busaddress
+
+        if ifname is not None:
+            link_dict: dict[str, Any] = {}
+
+            if link_info is not None:
+                li_dict = common.dataclass_to_dict(link_info)
+                del li_dict["ifindex"]
+                del li_dict["ifname"]
+            else:
+                li_dict = {}
+
+            li_address = li_dict.get("address")
+            if li_address is None:
+                li_address = get_address_from_ifname(ifname)
+
+            li_permaddr = li_dict.get("permaddr")
+            if li_permaddr is None:
+                li_permaddr = ethtool_permaddr(ifname=ifname)
+
+            dict_add_optional(link_dict, "address", li_address)
+            dict_add_optional(link_dict, "permaddr", li_permaddr)
+
+            if link_info is not None:
+                del li_dict["address"]
+                del li_dict["permaddr"]
+                if li_dict.get("link_info_kind", 1) is None:
+                    del li_dict["link_info_kind"]
+                link_dict.update(li_dict)
+
+            res["link"] = link_dict
+
+        if ifname is not None:
+            dict_add_optional(res, "phys_port_name", get_phys_port_name(ifname))
+            dict_add_optional(res, "phys_switch_id", get_phys_switch_id(ifname))
+
+        if pciaddr is not None:
+            dict_add_optional(res, "uplink_rep_ifname", get_uplink_representor(pciaddr))
+
+        if with_ethtool:
+            if ifname is not None:
+                ethdata = ethtool_driver(ifname=ifname)
+                if ethdata is not None:
+                    d3 = common.dataclass_to_dict(ethdata)
+                    del d3["ifname"]
+                    res["ethtool"] = d3
+
+        result.append(res)
+
+    uplink_reps: list[str] = sorted(
+        set(common.iter_filter_none(x1.get("uplink_rep_ifname") for x1 in result))
+    )
+
+    for uplink_rep_ifname in uplink_reps:
+        uplink_rep_pciaddr = get_pciaddr_from_ifname(uplink_rep_ifname)
+        if uplink_rep_pciaddr is None:
+            continue
+        vf_infos = get_vfs_for_representor(uplink_rep_pciaddr)
+        for vf_info in vf_infos:
+            vf_pciaddr, vf_index = vf_info
+
+            inf_vf = common.iter_get_first(
+                r for r in result if r.get("pciaddr") == vf_pciaddr
+            )
+
+            vf_rep = get_vf_representor(uplink_rep_ifname, vf_index)
+            if vf_rep is not None:
+                inf_vf_rep = common.iter_get_first(
+                    r for r in result if r.get("ifname") == vf_rep
+                )
+            else:
+                inf_vf_rep = None
+
+            d2: dict[str, Any] = {
+                "uplink_rep_ifname": uplink_rep_ifname,
+                "uplink_rep_pciaddr": uplink_rep_pciaddr,
+                "vfindex": vf_index,
+            }
+            if inf_vf is not None:
+                d3 = d2.copy()
+                if inf_vf_rep is not None:
+                    dict_add_optional(d3, "vf_rep_ifname", inf_vf_rep.get("ifname"))
+                    dict_add_optional(d3, "vf_rep_ifindex", inf_vf_rep.get("ifindex"))
+                    dict_add_optional(d3, "vf_rep_pciaddr", inf_vf_rep.get("pciaddr"))
+                inf_vf["is_vf"] = d3
+            if inf_vf_rep is not None:
+                d3 = d2.copy()
+                if inf_vf is not None:
+                    dict_add_optional(d3, "vf_ifname", inf_vf.get("ifname"))
+                    dict_add_optional(d3, "vf_ifindex", inf_vf.get("ifindex"))
+                    dict_add_optional(d3, "vf_pciaddr", inf_vf.get("pciaddr"))
+                inf_vf_rep["is_vf_rep"] = d3
+
+    result.sort(
+        key=lambda x: (
+            x.get("ifindex") or 2**33,
+            x.get("ifname") or "",
+            x.get("pciaddr") or "",
+        )
+    )
+
+    return result
+
+
+def device_infos_parse_lst(
+    device_infos_str: str,
+    *,
+    ifname: Optional[str] = None,
+    pciaddr: Optional[str] = None,
+    vf_rep_for_pciaddr: Optional[str] = None,
+) -> list[dict[str, Any]]:
+    lst = common.json_parse_list(device_infos_str)
+    return device_infos_find(
+        lst,
+        ifname=ifname,
+        pciaddr=pciaddr,
+        vf_rep_for_pciaddr=vf_rep_for_pciaddr,
+    )
+
+
+def device_infos_find(
+    device_info_list: Iterable[Any],
+    *,
+    ifname: Optional[str] = None,
+    pciaddr: Optional[str] = None,
+    vf_rep_for_pciaddr: Optional[str] = None,
+) -> list[dict[str, Any]]:
+
+    # First, filter out all non-strdicts
+    lst = [
+        di
+        for di in device_info_list
+        if (isinstance(di, dict) and all(isinstance(k, str) for k in di))
+    ]
+
+    if ifname is not None:
+        ifname = validate_ifname(ifname)
+        lst = [di for di in lst if di.get("ifname") == ifname]
+
+    if pciaddr is not None:
+        pciaddr = validate_ifname(pciaddr)
+        lst = [di for di in lst if di.get("pciaddr") == pciaddr]
+
+    if vf_rep_for_pciaddr is not None:
+
+        vf_rep_for_pciaddr = validate_pciaddr(vf_rep_for_pciaddr)
+
+        def _match(di: dict[str, Any]) -> bool:
+            x = di.get("is_vf_rep")
+            if not isinstance(x, dict):
+                return False
+            return x.get("vf_pciaddr") == vf_rep_for_pciaddr
+
+        lst = [di for di in lst if _match(di)]
+
+    return lst
+
+
+if __name__ == "__main__":
+
+    def main() -> None:
+        import argparse
+
+        commands = {f.__name__: f for f in (get_device_infos,)}
+
+        argparser = argparse.ArgumentParser(description="Helper network functions.")
+        argparser.add_argument(
+            "command",
+            choices=commands,
+            default="get_device_infos",
+            nargs="?",
+        )
+        args = argparser.parse_args()
+
+        result = commands[args.command]()
+        print(json.dumps(result))
+
+    main()

--- a/ktoolbox/test_common.py
+++ b/ktoolbox/test_common.py
@@ -1,0 +1,1102 @@
+import dataclasses
+import json
+import pytest
+import random
+import sys
+import typing
+
+from enum import Enum
+from typing import Any
+from typing import Optional
+from typing import Union
+
+from . import common
+
+from .common import enum_convert
+from .common import enum_convert_list
+from .common import serialize_enum
+
+
+class ReachedError(Exception):
+    pass
+
+
+class TstTestType(Enum):
+    IPERF_TCP = 1
+    IPERF_UDP = 2
+    HTTP = 3
+    NETPERF_TCP_STREAM = 4
+    NETPERF_TCP_RR = 5
+
+
+class TstPodType(Enum):
+    NORMAL = 1
+    SRIOV = 2
+    HOSTBACKED = 3
+
+
+def test_str_to_bool() -> None:
+    assert common.str_to_bool(True) is True
+    assert common.str_to_bool(False) is False
+
+    ERR = object()
+    DEF = object()
+
+    # falsy
+    assert common.str_to_bool("0") is False
+    assert common.str_to_bool("n") is False
+    assert common.str_to_bool("no") is False
+    assert common.str_to_bool("false") is False
+
+    # truthy
+    assert common.str_to_bool("1") is True
+    assert common.str_to_bool("y") is True
+    assert common.str_to_bool("yes") is True
+    assert common.str_to_bool("true") is True
+
+    assert common.str_to_bool("bogus", None) is None
+    assert common.str_to_bool("default", None) is None
+    assert common.str_to_bool("bogus", ERR) is ERR
+    assert common.str_to_bool("default", ERR) is ERR
+
+    assert common.str_to_bool("bogus", ERR, on_default=DEF) is ERR
+    assert common.str_to_bool("default", ERR, on_default=DEF) is DEF
+
+    with pytest.raises(TypeError):
+        common.str_to_bool("default", ERR, on_error=DEF)  # type: ignore
+
+    with pytest.raises(ValueError):
+        assert common.str_to_bool("bogus", on_default=DEF)
+    assert common.str_to_bool("bogus", on_default=DEF, on_error=ERR) is ERR
+    assert common.str_to_bool("bogus", on_error=ERR) is ERR
+    assert common.str_to_bool("default", on_default=DEF) is DEF
+    assert common.str_to_bool("default", on_default=DEF, on_error=ERR) is DEF
+    assert common.str_to_bool("default", on_error=ERR) is ERR
+
+    # edge cases
+    with pytest.raises(ValueError):
+        common.str_to_bool(None)
+    assert common.str_to_bool(None, on_default=DEF) is DEF
+    with pytest.raises(ValueError):
+        common.str_to_bool(0, on_default=DEF)  # type: ignore
+
+    obj = object()
+
+    assert common.str_to_bool("True", on_default=False) is True
+
+    assert common.str_to_bool("", on_default=obj) is obj
+
+    with pytest.raises(ValueError):
+        common.str_to_bool("")
+
+    assert common.str_to_bool(None, on_default=obj) is obj
+    assert common.str_to_bool("", on_default=obj) is obj
+    assert common.str_to_bool(" DEFAULT ", on_default=obj) is obj
+    assert common.str_to_bool(" -1 ", on_default=obj) is obj
+
+    assert common.str_to_bool(" -1 ", on_default=DEF) is DEF
+    assert common.str_to_bool(" -1 ", on_error=ERR) is ERR
+
+    assert common.str_to_bool("", on_default=DEF, on_error=ERR) is DEF
+    assert common.str_to_bool("", on_error=ERR) is ERR
+
+    with pytest.raises(ValueError):
+        common.str_to_bool("bogus")
+
+    assert common.str_to_bool("bogus", on_error=ERR) is ERR
+    assert common.str_to_bool("bogus", on_default=DEF, on_error=obj) is obj
+
+    assert common.bool_to_str(True) == "true"
+    assert common.bool_to_str(False) == "false"
+    assert common.bool_to_str(True, format="true") == "true"
+    assert common.bool_to_str(False, format="true") == "false"
+    assert common.bool_to_str(True, format="yes") == "yes"
+    assert common.bool_to_str(False, format="yes") == "no"
+    with pytest.raises(ValueError):
+        common.bool_to_str(False, format="bogus")
+
+    if sys.version_info >= (3, 10):
+        typing.assert_type(common.str_to_bool("true"), bool)
+        typing.assert_type(common.str_to_bool("true", on_error=None), bool | None)
+        typing.assert_type(common.str_to_bool("true", on_default=None), bool | None)
+        typing.assert_type(
+            common.str_to_bool("true", on_error=None, on_default=1), bool | None | int
+        )
+        typing.assert_type(
+            common.str_to_bool("true", on_error=2, on_default=1), bool | int
+        )
+        typing.assert_type(
+            common.str_to_bool("true", on_error=True, on_default="1"), bool | str
+        )
+        typing.assert_type(
+            common.str_to_bool("true", on_error=True, on_default="1"), bool | str
+        )
+
+
+def test_enum_convert() -> None:
+    assert enum_convert(TstTestType, "IPERF_TCP") == TstTestType.IPERF_TCP
+    assert enum_convert(TstPodType, 1) == TstPodType.NORMAL
+    assert enum_convert(TstPodType, "1 ") == TstPodType.NORMAL
+    assert enum_convert(TstPodType, " normal") == TstPodType.NORMAL
+    with pytest.raises(ValueError):
+        enum_convert(TstTestType, "Not_in_enum")
+    with pytest.raises(ValueError):
+        enum_convert(TstTestType, 10000)
+
+    assert enum_convert_list(TstTestType, [1]) == [TstTestType.IPERF_TCP]
+    assert enum_convert_list(TstTestType, [TstTestType.IPERF_TCP]) == [
+        TstTestType.IPERF_TCP
+    ]
+    assert enum_convert_list(TstTestType, ["iperf-tcp"]) == [TstTestType.IPERF_TCP]
+    assert enum_convert_list(TstTestType, ["iperf_tcp-1,3", 2]) == [
+        TstTestType.IPERF_TCP,
+        TstTestType.HTTP,
+        TstTestType.IPERF_UDP,
+    ]
+
+    class E1(Enum):
+        Vm4 = -4
+        V1 = 1
+        V1b = 1
+        v2 = 2
+        V2 = 3
+        V_7 = 10
+        V_3 = 6
+        v_3 = 7
+        V5 = 5
+
+    assert enum_convert(E1, "v5") == E1.V5
+    assert enum_convert(E1, "v2") == E1.v2
+    assert enum_convert(E1, "V2") == E1.V2
+    assert enum_convert(E1, "v_3") == E1.v_3
+    assert enum_convert(E1, "V_3") == E1.V_3
+    assert enum_convert(E1, "V_7") == E1.V_7
+    assert enum_convert(E1, "V-7") == E1.V_7
+    with pytest.raises(ValueError):
+        assert enum_convert(E1, "v-3") == E1.v_3
+    with pytest.raises(ValueError):
+        assert enum_convert(E1, "V-3") == E1.V_3
+    assert enum_convert(E1, "10") == E1.V_7
+    assert enum_convert(E1, "-4") == E1.Vm4
+    assert enum_convert(E1, "1") == E1.V1
+
+
+def test_serialize_enum() -> None:
+    # Test with enum value
+    assert serialize_enum(TstTestType.IPERF_TCP) == "IPERF_TCP"
+
+    # Test with a dictionary containing enum values
+    data = {
+        "test_type": TstTestType.IPERF_UDP,
+        "pod_type": TstPodType.SRIOV,
+        "other_key": "some_value",
+    }
+    serialized_data = serialize_enum(data)
+    assert serialized_data == {
+        "test_type": "IPERF_UDP",
+        "pod_type": "SRIOV",
+        "other_key": "some_value",
+    }
+
+    # Test with a list containing enum values
+    data_list = [TstTestType.HTTP, TstPodType.HOSTBACKED]
+    serialized_list = serialize_enum(data_list)
+    assert serialized_list == ["HTTP", "HOSTBACKED"]
+
+    class TstTestCaseType(Enum):
+        POD_TO_HOST_SAME_NODE = 5
+
+    class TstConnectionMode(Enum):
+        EXTERNAL_IP = 1
+
+    class TstNodeLocation(Enum):
+        SAME_NODE = 1
+
+    # Test with nested structures
+    nested_data = {
+        "nested_dict": {"test_case_id": TstTestCaseType.POD_TO_HOST_SAME_NODE},
+        "nested_list": [TstConnectionMode.EXTERNAL_IP, TstNodeLocation.SAME_NODE],
+    }
+    serialized_nested_data = serialize_enum(nested_data)
+    assert serialized_nested_data == {
+        "nested_dict": {"test_case_id": "POD_TO_HOST_SAME_NODE"},
+        "nested_list": ["EXTERNAL_IP", "SAME_NODE"],
+    }
+
+    # Test with non-enum value
+    assert serialize_enum("some_string") == "some_string"
+    assert serialize_enum(123) == 123
+
+
+def test_strict_dataclass() -> None:
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C2:
+        a: str
+        b: int
+        c: typing.Optional[str] = None
+
+    C2("a", 5)
+    C2("a", 5, None)
+    C2("a", 5, "")
+    with pytest.raises(TypeError):
+        C2("a", "5")  # type: ignore
+    with pytest.raises(TypeError):
+        C2(3, 5)  # type: ignore
+    with pytest.raises(TypeError):
+        C2("a", 5, [])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C3:
+        a: typing.List[str]
+
+    C3([])
+    C3([""])
+    with pytest.raises(TypeError):
+        C3(1)  # type: ignore
+    with pytest.raises(TypeError):
+        C3([1])  # type: ignore
+    with pytest.raises(TypeError):
+        C3(None)  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C4:
+        a: typing.Optional[typing.List[str]]
+
+    C4(None)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C5:
+        a: typing.Optional[typing.List[typing.Dict[str, str]]] = None
+
+    C5(None)
+    C5([])
+    with pytest.raises(TypeError):
+        C5([1])  # type: ignore
+    C5([{}])
+    C5([{"a": "b"}])
+    C5([{"a": "b"}, {}])
+    C5([{"a": "b"}, {"c": "", "d": "x"}])
+    with pytest.raises(TypeError):
+        C5([{"a": None}])  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C6:
+        a: typing.Optional[typing.Tuple[str, str]] = None
+
+    C6()
+    C6(None)
+    C6(("a", "b"))
+    with pytest.raises(TypeError):
+        C6(1)  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a",))  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a", "b", "c"))  # type: ignore
+    with pytest.raises(TypeError):
+        C6(("a", 1))  # type: ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass(frozen=True)
+    class TstPodInfo:
+        name: str
+        pod_type: TstPodType
+        is_tenant: bool
+        index: int
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C7:
+        addr_info: typing.List[TstPodInfo]
+
+        def _post_check(self) -> None:
+            pass
+
+    with pytest.raises(TypeError):
+        C7(None)  # type: ignore
+    C7([])
+    C7([TstPodInfo("name", TstPodType.NORMAL, True, 5)])
+    with pytest.raises(TypeError):
+        C7([TstPodInfo("name", TstPodType.NORMAL, True, 5), None])  # type:ignore
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C8:
+        a: str
+
+        def _post_check(self) -> None:
+            if self.a == "invalid":
+                raise ValueError("_post_check() failed")
+
+    with pytest.raises(TypeError):
+        C8(None)  # type: ignore
+    C8("hi")
+    with pytest.raises(ValueError):
+        C8("invalid")
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C9:
+        a: "str"
+
+    with pytest.raises(NotImplementedError):
+        C9("foo")
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C10:
+        x: float
+
+    C10(1.0)
+    with pytest.raises(TypeError):
+        C10(1)
+
+
+def test_dataclass_tofrom_dict() -> None:
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C1:
+        foo: int
+        str: typing.Optional[str]
+
+    c1 = C1(1, "str")
+    d1 = common.dataclass_to_dict(c1)
+    assert c1 == common.dataclass_from_dict(C1, d1)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C2:
+        enum_val: TstTestType
+        c1_opt: typing.Optional[C1]
+        c1_opt_2: typing.Optional[C1]
+        c1_list: list[C1]
+
+    c2 = C2(TstTestType.IPERF_UDP, C1(2, "2"), None, [C1(3, "3"), C1(4, "4")])
+    d2 = common.dataclass_to_dict(c2)
+    assert (
+        json.dumps(d2)
+        == '{"enum_val": "IPERF_UDP", "c1_opt": {"foo": 2, "str": "2"}, "c1_opt_2": null, "c1_list": [{"foo": 3, "str": "3"}, {"foo": 4, "str": "4"}]}'
+    )
+    assert c2 == common.dataclass_from_dict(C2, d2)
+
+    @common.strict_dataclass
+    @dataclasses.dataclass
+    class C10:
+        x: float
+
+    assert common.dataclass_to_dict(C10(1.0)) == {"x": 1.0}
+
+    c10 = C10(1.0)
+    assert type(c10.x) is float
+    common.dataclass_check(c10)
+    c10.x = 1
+    assert type(c10.x) is int
+    with pytest.raises(TypeError):
+        common.dataclass_check(c10)
+    assert common.dataclass_to_dict(c10) == {"x": 1}
+
+    assert common.dataclass_from_dict(C10, {"x": 1.0}) == c10
+    assert common.dataclass_from_dict(C10, {"x": 1.0}) == C10(1.0)
+    assert common.dataclass_from_dict(C10, {"x": 1}) == c10
+    assert common.dataclass_from_dict(C10, {"x": 1}) == C10(1.0)
+    assert type(common.dataclass_from_dict(C10, {"x": 1}).x) is float
+    assert type(common.dataclass_from_dict(C10, {"x": 1.0}).x) is float
+    assert type(c10.x) is int
+    assert type(C10(1.0).x) is float
+
+
+def test_kw_only() -> None:
+    common.StructParseBaseNamed(yamlpath="yamlpath", yamlidx=0, name="name")
+    if sys.version_info >= (3, 10):
+        assert common.KW_ONLY_DATACLASS == {"kw_only": True}
+        with pytest.raises(TypeError):
+            common.StructParseBaseNamed("yamlpath", yamlidx=0, name="name")
+        with pytest.raises(TypeError):
+            common.StructParseBaseNamed("yamlpath", 0, "name")
+    else:
+        assert common.KW_ONLY_DATACLASS == {}
+        common.StructParseBaseNamed("yamlpath", yamlidx=0, name="name")
+        common.StructParseBaseNamed("yamlpath", 0, "name")
+
+
+def test_etc_hosts_update() -> None:
+    assert common.etc_hosts_update_data("", {}) == ""
+    assert common.etc_hosts_update_data("a", {}) == "a\n"
+
+    assert (
+        common.etc_hosts_update_data(
+            "",
+            {
+                "foo": ("192.168.1.3", []),
+            },
+        )
+        == "192.168.1.3 foo\n"
+    )
+    assert (
+        common.etc_hosts_update_data(
+            "10.2.3.4 foo\n",
+            {
+                "foo": ("192.168.1.3", None),
+            },
+        )
+        == "192.168.1.3 foo\n"
+    )
+    assert (
+        common.etc_hosts_update_data(
+            "  \t 10.2.3.4\tfoo foo.alias\t",
+            {
+                "foo": ("192.168.1.3", ["foo2"]),
+                "bar": ("192.168.1.1", None),
+            },
+        )
+        == "192.168.1.3 foo foo2\n\n192.168.1.1 bar\n"
+    )
+
+    assert (
+        common.etc_hosts_update_data(
+            b"  1.1.1.1 xx\xcaxx\n  \t 10.2.3.4\tfoo foo.alias\t".decode(
+                errors="surrogateescape"
+            ),
+            {
+                "foo": ("192.168.1.3", ["foo2"]),
+                "bar": ("192.168.1.1", None),
+            },
+        ).encode(errors="surrogateescape")
+        == b"  1.1.1.1 xx\xcaxx\n192.168.1.3 foo foo2\n\n192.168.1.1 bar\n"
+    )
+
+    assert (
+        common.etc_hosts_update_data(
+            """127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.131.100.100 marvell-dpu-42 dpu
+""",
+            {
+                "marvell-dpu-42": ("172.131.100.100", ["dpu"]),
+            },
+        )
+        == """127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.131.100.100 marvell-dpu-42 dpu
+"""
+    )
+
+    assert (
+        common.etc_hosts_update_data(
+            """127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.131.100.100 marvell-dpu-42 dpu
+""",
+            {
+                "marvell-dpu-42": ("172.131.100.100", ["dpu2"]),
+            },
+        )
+        == """127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.131.100.100 marvell-dpu-42 dpu2
+"""
+    )
+
+
+def test_serial() -> None:
+    try:
+        import serial
+    except ModuleNotFoundError:
+        pytest.skip("pyserial module not available")
+
+    with pytest.raises(serial.serialutil.SerialException):
+        common.Serial("")
+
+
+def test_structparse_with() -> None:
+
+    with common.structparse_with_strdict({}, "path") as varg:
+        with pytest.raises(ValueError):
+            v1 = common.structparse_pop_str(*varg.for_key("v1"))
+            if sys.version_info >= (3, 10):
+                typing.assert_type(v1, str)
+
+        v22 = common.structparse_pop_list({}, "path", "foo")
+        if sys.version_info >= (3, 10):
+            typing.assert_type(v22, list[Any])
+        assert v22 == []
+
+        v33n = common.structparse_pop_list(*varg.for_key("v33n"))
+        if sys.version_info >= (3, 10):
+            typing.assert_type(v33n, list[Any])
+        assert v33n == []
+
+        v3 = common.structparse_pop_enum(
+            *varg.for_key("v3"),
+            enum_type=TstTestType,
+            default=TstTestType.IPERF_TCP,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(v3, TstTestType)
+        assert v3 == TstTestType.IPERF_TCP
+
+        v4 = common.structparse_pop_enum(
+            *varg.for_key("v3"),
+            enum_type=TstTestType,
+            default=None,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(v4, Optional[TstTestType])
+        assert v4 is None
+
+
+def test_structparse_pop_str_1() -> None:
+    with pytest.raises(ValueError):
+        val0 = common.structparse_pop_str(
+            {},
+            "path",
+            "foo",
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(val0, str)
+
+    val1 = common.structparse_pop_str(
+        {},
+        "path",
+        "foo",
+        default=None,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val1, Optional[str])
+    assert val1 is None
+
+    val2 = common.structparse_pop_str(
+        {},
+        "path",
+        "foo",
+        default="defval",
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val2, str)
+    assert val2 == "defval"
+
+    val3 = common.structparse_pop_str(
+        {"foo": "strval"},
+        "path",
+        "foo",
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val3, str)
+    assert val3 == "strval"
+
+    val4 = common.structparse_pop_str(
+        {"foo": "strval"},
+        "path",
+        "foo",
+        default=None,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val4, Optional[str])
+    assert val4 == "strval"
+
+    val5 = common.structparse_pop_str(
+        {"foo": "strval"},
+        "path",
+        "foo",
+        default="defval",
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val5, str)
+    assert val5 == "strval"
+
+
+def test_structparse_pop_str_empty() -> None:
+    def varg() -> tuple[dict[str, Any], str, str]:
+        return (
+            {"foo": ""},
+            "path",
+            "foo",
+        )
+
+    def _check(x: str) -> bool:
+        assert x == ""
+        raise ReachedError("I am here")
+
+    def rnd_ntf() -> Optional[bool]:
+        return random.choice([None, True, False])
+
+    def rnd_check() -> Optional[typing.Callable[[str], bool]]:
+        return random.choice([None, _check])
+
+    def rnd_default() -> Optional[str]:
+        return random.choice([None, "xxx"])
+
+    # if nothing specified, empty values are rejected.
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg())
+
+    # If we have a default, the empty value maps to the default.
+    assert common.structparse_pop_str(*varg(), default=None) is None
+    assert common.structparse_pop_str(*varg(), default="xxx") == "xxx"
+
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg(), empty_as_default=None)
+    assert common.structparse_pop_str(*varg(), empty_as_default=False) == ""
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg(), empty_as_default=True)
+
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg(), allow_empty=None)
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg(), allow_empty=False)
+    assert common.structparse_pop_str(*varg(), allow_empty=True) == ""
+
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg(), check=None)
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg(), check=_check)
+
+    for i in range(1000):
+
+        with pytest.raises(ValueError):
+            common.structparse_pop_str(
+                *varg(),
+                default=random.choice([common.MISSING, None, "xxx"]),
+                empty_as_default=random.choice([None, False, True]),
+                allow_empty=False,
+                check=random.choice([None, _check]),
+            )
+
+        d1 = random.choice([None, "xxx"])
+        assert (
+            common.structparse_pop_str(
+                *varg(),
+                default=d1,
+                empty_as_default=True,
+                allow_empty=random.choice([None, True]),
+                check=random.choice([None, _check]),
+            )
+            is d1
+        )
+
+        assert (
+            common.structparse_pop_str(
+                *varg(),
+                default=random.choice([None, "xxx"]),
+                empty_as_default=False,
+                allow_empty=random.choice([None, True]),
+                check=None,
+            )
+            == ""
+        )
+        with pytest.raises(ReachedError):
+            common.structparse_pop_str(
+                *varg(),
+                default=random.choice([None, "xxx"]),
+                empty_as_default=False,
+                allow_empty=random.choice([None, True]),
+                check=_check,
+            )
+
+    assert (
+        common.structparse_pop_str(
+            *varg(),
+            default="xxx",
+            empty_as_default=False,
+        )
+        == ""
+    )
+
+    assert common.structparse_pop_str(*varg(), default="xxx", check=_check) == "xxx"
+    assert (
+        common.structparse_pop_str(
+            *varg(), default="xxx", empty_as_default=True, check=_check
+        )
+        == "xxx"
+    )
+    with pytest.raises(ReachedError):
+        common.structparse_pop_str(
+            *varg(), default="xxx", empty_as_default=False, check=_check
+        )
+
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg(), empty_as_default=True, check=_check)
+    with pytest.raises(ReachedError):
+        common.structparse_pop_str(*varg(), empty_as_default=False, check=_check)
+
+    with pytest.raises(ReachedError):
+        common.structparse_pop_str(*varg(), allow_empty=True, check=_check)
+    with pytest.raises(ValueError):
+        common.structparse_pop_str(*varg(), allow_empty=False, check=_check)
+
+
+def test_structparse_pop_bool() -> None:
+    for test_val in (None, "", "default", "-1", "bogus"):
+        with pytest.raises(ValueError):
+            val0c = common.structparse_pop_bool(
+                {"foo": test_val},
+                "path",
+                "foo",
+            )
+            if sys.version_info >= (3, 10):
+                typing.assert_type(val0c, bool)
+
+    with pytest.raises(ValueError):
+        val0a = common.structparse_pop_bool(
+            {"foo": "bogus"},
+            "path",
+            "foo",
+            default=False,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(val0a, bool)
+
+    with pytest.raises(ValueError):
+        val0b = common.structparse_pop_bool(
+            {"foo": "bogus"},
+            "path",
+            "foo",
+            default=None,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(val0b, Optional[bool])
+
+    for test_val in (None, "", "default", "-1"):
+        val0d = common.structparse_pop_bool(
+            {"foo": test_val},
+            "path",
+            "foo",
+            default=False,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(val0d, bool)
+        assert val0d is False
+
+    for test_val in (None, "", "default", "-1"):
+        val0e = common.structparse_pop_bool(
+            {"foo": test_val},
+            "path",
+            "foo",
+            default=None,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(val0e, Optional[bool])
+        assert val0e is None
+
+    val1 = common.structparse_pop_bool(
+        {},
+        "path",
+        "foo",
+        default=None,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val1, Optional[bool])
+    assert val1 is None
+
+    val2 = common.structparse_pop_bool(
+        {},
+        "path",
+        "foo",
+        default=False,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val2, bool)
+    assert val2 is False
+
+    val3 = common.structparse_pop_bool(
+        {"foo": "true"},
+        "path",
+        "foo",
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val3, bool)
+    assert val3 is True
+
+    val4 = common.structparse_pop_bool(
+        {"foo": "1"},
+        "path",
+        "foo",
+        default=None,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val4, Optional[bool])
+    assert val4 is True
+
+    val5 = common.structparse_pop_bool(
+        {"foo": "yes"},
+        "path",
+        "foo",
+        default=False,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val5, bool)
+    assert val5 is True
+
+
+def test_structparse_pop_enum() -> None:
+    with pytest.raises(ValueError):
+        val0 = common.structparse_pop_enum(
+            {},
+            "path",
+            "foo",
+            enum_type=TstTestType,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(val0, TstTestType)
+
+    val1 = common.structparse_pop_enum(
+        {},
+        "path",
+        "foo",
+        enum_type=TstTestType,
+        default=None,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val1, Optional[TstTestType])
+    assert val1 is None
+
+    val2 = common.structparse_pop_enum(
+        {},
+        "path",
+        "foo",
+        enum_type=TstTestType,
+        default=TstTestType.IPERF_TCP,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val2, TstTestType)
+    assert val2 == TstTestType.IPERF_TCP
+
+    val3 = common.structparse_pop_enum(
+        {"foo": "http"},
+        "path",
+        "foo",
+        enum_type=TstTestType,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val3, TstTestType)
+    assert val3 == TstTestType.HTTP
+
+    val4 = common.structparse_pop_enum(
+        {"foo": "http"},
+        "path",
+        "foo",
+        enum_type=TstTestType,
+        default=None,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val4, Optional[TstTestType])
+    assert val4 == TstTestType.HTTP
+
+    val5 = common.structparse_pop_enum(
+        {"foo": "http"},
+        "path",
+        "foo",
+        enum_type=TstTestType,
+        default=TstTestType.IPERF_TCP,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val5, TstTestType)
+    assert val5 == TstTestType.HTTP
+
+
+def test_structparse_pop_obj() -> None:
+    def args(arg: Optional[Any]) -> tuple[dict[str, Any], str, str]:
+        vdict: dict[str, Any] = {}
+        if arg is not None:
+            vdict["foo"] = arg
+        return vdict, "path", "foo"
+
+    def _construct(yamlidx2: int, yamlpath2: str, arg: Any) -> int:
+        if arg is None:
+            return -1
+        return int(arg)
+
+    v1 = common.structparse_pop_obj(
+        *args("4"),
+        construct=_construct,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(v1, int)
+    assert v1 == 4
+
+    with pytest.raises(ValueError):
+        v2 = common.structparse_pop_obj(
+            *args(None),
+            construct=_construct,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(v2, int)
+        assert False
+
+    v3 = common.structparse_pop_obj(
+        *args(None),
+        construct=_construct,
+        default=None,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(v3, Optional[int])
+    assert v3 is None
+
+    v4 = common.structparse_pop_obj(
+        *args(None),
+        construct=_construct,
+        default=99,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(v4, int)
+    assert v4 == 99
+
+    v5 = common.structparse_pop_obj(
+        *args(None),
+        construct=_construct,
+        default="99",
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(v5, Union[int, str])
+    assert v5 == "99"
+
+    v6 = common.structparse_pop_obj(
+        *args(None),
+        construct=_construct,
+        construct_default=True,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(v6, int)
+    assert v6 == -1
+
+
+def test_structparse_pop_list() -> None:
+    def args(lst: Optional[list[Any]]) -> tuple[dict[str, Any], str, str]:
+        vdict: dict[str, Any] = {}
+        if lst is not None:
+            vdict["foo"] = lst
+        return vdict, "path", "foo"
+
+    lst1 = common.structparse_pop_list({}, "path", "foo")
+    if sys.version_info >= (3, 10):
+        typing.assert_type(lst1, list[Any])
+    assert lst1 == []
+
+    lst2 = common.structparse_pop_list(*args(None))
+    if sys.version_info >= (3, 10):
+        typing.assert_type(lst2, list[Any])
+    assert lst2 == []
+
+    with pytest.raises(ValueError):
+        lst7 = common.structparse_pop_list(*args(None), allow_missing=False)
+        if sys.version_info >= (3, 10):
+            typing.assert_type(lst7, list[Any])
+        assert False
+
+    lst9 = common.structparse_pop_list(*args(None), allow_missing=True)
+    if sys.version_info >= (3, 10):
+        typing.assert_type(lst9, list[Any])
+    assert lst9 == []
+
+    with pytest.raises(ValueError):
+        lst17 = common.structparse_pop_list(*args(None), allow_empty=False)
+        if sys.version_info >= (3, 10):
+            typing.assert_type(lst17, list[Any])
+        assert False
+
+    lst19 = common.structparse_pop_list(*args(None), allow_empty=True)
+    if sys.version_info >= (3, 10):
+        typing.assert_type(lst19, list[Any])
+    assert lst19 == []
+
+    lst8 = common.structparse_pop_list(*args([]), allow_missing=False)
+    if sys.version_info >= (3, 10):
+        typing.assert_type(lst8, list[Any])
+    assert lst8 == []
+
+    lst21 = common.structparse_pop_list(
+        *args([]),
+        allow_missing=False,
+        allow_empty=True,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(lst21, list[Any])
+    assert lst21 == []
+
+
+def test_structparse_pop_objlist_as_dict() -> None:
+    def do_dict(
+        key: str,
+        vdict: dict[str, Any],
+        *,
+        allow_duplicates: bool = False,
+    ) -> dict[int, tuple[int, str, int]]:
+        val0 = common.structparse_pop_objlist_to_dict(
+            vdict,
+            "path",
+            key,
+            construct=lambda yamlidx2, yamlpath2, arg: (yamlidx2, yamlpath2, int(arg)),
+            get_key=lambda v: int(v[2]),
+            allow_duplicates=allow_duplicates,
+        )
+        if sys.version_info >= (3, 10):
+            typing.assert_type(val0, dict[int, tuple[int, str, int]])
+        return val0
+
+    def do(
+        vlst: list[Any],
+        *,
+        allow_duplicates: bool = False,
+    ) -> dict[int, tuple[int, str, int]]:
+        return do_dict("foo", {"foo": vlst}, allow_duplicates=allow_duplicates)
+
+    assert do_dict("foo", {}) == {}
+    assert do_dict("foo", {"foo": []}) == {}
+    assert do([]) == {}
+    val7: dict[int, tuple[int, str, int]] = do(["1"])
+    assert val7 == {1: (0, "path.foo[0]", 1)}
+    assert do(["1", "2"]) == {
+        1: (0, "path.foo[0]", 1),
+        2: (1, "path.foo[1]", 2),
+    }
+    with pytest.raises(ValueError) as ex:
+        do(["1", "2", "1"])
+    assert str(ex.value) == '"path.foo[2]": duplicate key \'1\' with "path.foo[0]"'
+    assert do(["1", "2", "1"], allow_duplicates=True) == {
+        2: (1, "path.foo[1]", 2),
+        1: (2, "path.foo[2]", 1),
+    }
+
+    val1 = common.structparse_pop_objlist_to_dict(
+        {"foo": [0, 1, 2]},
+        "path",
+        "foo",
+        construct=lambda yamlidx2, yamlpath2, arg: common.StructParseBaseNamed(
+            yamlpath=yamlpath2,
+            yamlidx=yamlidx2,
+            name=str(arg),
+        ),
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val1, dict[str, common.StructParseBaseNamed])
+    assert val1 == {
+        "0": common.StructParseBaseNamed(yamlidx=0, yamlpath="path.foo[0]", name="0"),
+        "1": common.StructParseBaseNamed(yamlidx=1, yamlpath="path.foo[1]", name="1"),
+        "2": common.StructParseBaseNamed(yamlidx=2, yamlpath="path.foo[2]", name="2"),
+    }
+
+    val2 = common.structparse_pop_objlist_to_dict(
+        {"foo": [0, 1, 2]},
+        "path",
+        "foo",
+        construct=lambda yamlidx2, yamlpath2, arg: str(arg),
+        get_key=lambda x: x,
+    )
+    if sys.version_info >= (3, 10):
+        typing.assert_type(val2, dict[str, str])
+
+    with pytest.raises(RuntimeError):
+        common.structparse_pop_objlist_to_dict(  # type:ignore
+            {"foo": [0, 1, 2]},
+            "path",
+            "foo",
+            construct=lambda yamlidx2, yamlpath2, arg: str(arg),
+        )

--- a/ktoolbox/test_firewall.py
+++ b/ktoolbox/test_firewall.py
@@ -1,0 +1,28 @@
+from . import firewall
+
+
+def test_nft_cmd_masquerade() -> None:
+    assert (
+        firewall.nft_data_masquerade_down(table_name="foo")
+        == """add table ip foo
+delete table ip foo
+"""
+    )
+    assert (
+        firewall.nft_data_masquerade_up(
+            table_name="foo",
+            subnet="191.168.5.0/24",
+            ifname="eno4",
+        )
+        == """add table ip foo
+flush table ip foo
+add chain ip foo nat_postrouting { type nat hook postrouting priority 100; policy accept; };
+add rule ip foo nat_postrouting ip saddr 191.168.5.0/24 ip daddr != 191.168.5.0/24 masquerade;
+add chain ip foo filter_forward { type filter hook forward priority 0; policy accept; };
+add rule ip foo filter_forward ip daddr 191.168.5.0/24 oifname "eno4"  ct state { established, related } accept;
+add rule ip foo filter_forward ip saddr 191.168.5.0/24 iifname "eno4" accept;
+add rule ip foo filter_forward iifname "eno4" oifname "eno4" accept;
+add rule ip foo filter_forward iifname "eno4" reject;
+add rule ip foo filter_forward oifname "eno4" reject;
+"""
+    )

--- a/ktoolbox/test_host.py
+++ b/ktoolbox/test_host.py
@@ -1,0 +1,372 @@
+import functools
+import logging
+import os
+import pathlib
+import pytest
+import random
+import sys
+
+from collections.abc import Mapping
+from typing import Any
+from typing import Optional
+from typing import Union
+
+from . import host
+
+
+def _rnd_log_lineoutput() -> dict[str, Any]:
+    r = random.randint(0, 4)
+
+    val: Optional[Union[int, bool]] = None
+    if r <= 1:
+        val = r == 0
+    elif r == 2:
+        val = -1
+    elif r == 3:
+        val = logging.DEBUG
+    else:
+        val = logging.ERROR
+
+    if val is None:
+        return {}
+    return {
+        "log_lineoutput": val,
+    }
+
+
+@functools.cache
+def get_user() -> Optional[str]:
+    return os.environ.get("USER")
+
+
+@functools.cache
+def has_sudo(rsh: host.Host) -> bool:
+    r = rsh.run("sudo -n whoami")
+    return r == host.Result("root\n", "", 0)
+
+
+@functools.cache
+def has_paramiko() -> bool:
+    try:
+        import paramiko
+
+        assert paramiko.client
+        return True
+    except ModuleNotFoundError:
+        return False
+
+
+@functools.cache
+def can_ssh_nopass(hostname: str, user: str) -> Optional[host.RemoteHost]:
+
+    if not has_paramiko():
+        return None
+
+    import paramiko
+
+    client = paramiko.client.SSHClient()
+    client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        client.connect(hostname, username=user, password="")
+    except Exception:
+        pass
+    else:
+        _in, _out, _err = client.exec_command("echo -n hello")
+        _in.close()
+        s_out = _out.read()
+        s_err = _err.read()
+        rc = _out.channel.recv_exit_status()
+        if rc == 0 and s_out == b"hello" and s_err == b"":
+            rsh = host.RemoteHost(hostname, host.AutoLogin(user))
+            assert rsh.run("whoami") == host.Result(f"{user}\n", "", 0)
+            return rsh
+    return None
+
+
+def run_local(
+    cmd: Union[str, list[str]],
+    *,
+    text: bool = True,
+    env: Optional[Mapping[str, Optional[str]]] = None,
+    cwd: Optional[str] = None,
+) -> Union[host.Result, host.BinResult]:
+    res = host.local.run(cmd, text=text, cwd=cwd, env=env)
+
+    rsh = can_ssh_nopass("localhost", get_user())
+    if rsh is not None:
+        res2 = rsh.run(cmd, text=text, cwd=cwd, env=env)
+        assert res == res2
+
+    return res
+
+
+def skip_without_paramiko() -> None:
+    if not has_paramiko():
+        pytest.skip("paramiko module is not available")
+
+
+def skip_without_ssh_nopass(
+    hostname: str = "localhost",
+    user: Optional[str] = None,
+) -> tuple[str, host.RemoteHost]:
+    if user is None:
+        user = get_user() or "root"
+    skip_without_paramiko()
+    rsh = can_ssh_nopass(hostname, user)
+    if rsh is None:
+        pytest.skip(f"cannot ssh to {user}@{hostname} without password")
+    return user, rsh
+
+
+def skip_without_sudo(rsh: host.Host) -> None:
+    if not has_sudo(rsh):
+        pytest.skip(f"sudo on {rsh.pretty_str()} does not seem to work passwordless")
+
+
+def test_host_result_bin() -> None:
+    res = run_local("echo -n out; echo -n err >&2", text=False)
+    assert res == host.BinResult(b"out", b"err", 0)
+
+
+def test_host_result_surrogateescape() -> None:
+    res = host.local.run(
+        "echo -n hi", decode_errors="surrogateescape", **_rnd_log_lineoutput()
+    )
+    assert res == host.Result("hi", "", 0)
+
+    cmd = ["bash", "-c", "printf $'xx<\\325>'"]
+
+    res_bin = host.local.run(cmd, text=False, **_rnd_log_lineoutput())
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+    res = host.local.run(cmd, decode_errors="surrogateescape")
+    assert res == host.Result("xx<\udcd5>", "", 0)
+    with pytest.raises(UnicodeEncodeError):
+        res.out.encode()
+    assert res.out.encode(errors="surrogateescape") == b"xx<\325>"
+
+    res_bin2 = run_local(["bash", "-c", 'printf "xx<\udcd5>"'], text=False)
+    assert res_bin2 == host.BinResult(b"xx<\325>", b"", 0)
+
+    res_bin = run_local(["echo", "-n", "xx<\udcd5>"], text=False)
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+    cmd2 = b'echo -n "xx<\325>"'.decode(errors="surrogateescape")
+    res_bin = host.local.run(cmd2, text=False)
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+    t = False
+    res_any = host.local.run(cmd2, text=t, **_rnd_log_lineoutput())
+    assert isinstance(res_any, host.BinResult)
+    assert res_any == host.BinResult(b"xx<\325>", b"", 0)
+
+    res = host.local.run(cmd2)
+    assert res == host.Result("xx<�>", "", 0)
+
+    res = host.local.run(cmd2, decode_errors="surrogateescape")
+    assert res == host.Result("xx<\udcd5>", "", 0)
+
+    res_bin = host.local.run(["bash", "-c", cmd2], text=False)
+    assert res_bin == host.BinResult(b"xx<\325>", b"", 0)
+
+
+def test_host_result_str() -> None:
+    res = host.local.run("echo -n out; echo -n err >&2", text=True)
+    assert res == host.Result("out", "err", 0)
+
+    res = host.local.run("echo -n out; echo -n err >&2", **_rnd_log_lineoutput())
+    assert res == host.Result("out", "err", 0)
+
+
+def test_host_various_results() -> None:
+    res = host.local.run('printf "foo:\\705x"')
+    assert res == host.Result("foo:\ufffdx", "", 0)
+
+    # The result with decode_errors="replace" is the same as if decode_errors
+    # is left unspecified. However, the latter case will log an ERROR message
+    # when seeing unexpected binary. If you set decode_errors, you expect
+    # binary, and no error message is logged.
+    res = host.local.run('printf "foo:\\705x"', decode_errors="replace")
+    assert res == host.Result("foo:\ufffdx", "", 0)
+
+    res = host.local.run('printf "foo:\\705x"', decode_errors="ignore")
+    assert res == host.Result("foo:x", "", 0)
+
+    with pytest.raises(UnicodeDecodeError):
+        res = host.local.run('printf "foo:\\705x"', decode_errors="strict")
+
+    res = host.local.run(
+        'printf "foo:\\705x"', decode_errors="backslashreplace", **_rnd_log_lineoutput()
+    )
+    assert res == host.Result("foo:\\xc5x", "", 0)
+
+    binres = host.local.run('printf "foo:\\705x"', text=False)
+    assert binres == host.BinResult(b"foo:\xc5x", b"", 0)
+
+
+def test_host_check_success() -> None:
+
+    res = host.local.run("echo -n foo", check_success=lambda r: r.success)
+    assert res == host.Result("foo", "", 0)
+    assert res.success
+
+    res = host.local.run("echo -n foo", check_success=lambda r: r.out != "foo")
+    assert res == host.Result("foo", "", 0, forced_success=False)
+    assert not res.success
+
+    binres = host.local.run(
+        "echo -n foo",
+        text=False,
+        check_success=lambda r: r.out != b"foo",
+        **_rnd_log_lineoutput(),
+    )
+    assert binres == host.BinResult(b"foo", b"", 0, forced_success=False)
+    assert not binres.success
+
+    res = host.local.run("echo -n foo; exit 74", check_success=lambda r: r.success)
+    assert res == host.Result("foo", "", 74)
+    assert not res.success
+
+    res = host.local.run("echo -n foo; exit 74", check_success=lambda r: r.out == "foo")
+    assert res == host.Result("foo", "", 74, forced_success=True)
+    assert res.success
+
+    binres = host.local.run(
+        "echo -n foo; exit 74", text=False, check_success=lambda r: r.out == b"foo"
+    )
+    assert binres == host.BinResult(b"foo", b"", 74, forced_success=True)
+    assert binres.success
+
+
+def test_host_file_exists() -> None:
+    assert host.local.file_exists(__file__)
+    assert host.Host.file_exists(host.local, __file__)
+    assert host.local.file_exists(os.path.dirname(__file__))
+    assert host.Host.file_exists(host.local, os.path.dirname(__file__))
+
+    assert host.local.file_exists(pathlib.Path(__file__))
+    assert host.Host.file_exists(host.local, pathlib.Path(__file__))
+
+
+def test_result_typing() -> None:
+    host.Result("out", "err", 0)
+    host.Result("out", "err", 0, forced_success=True)
+    host.BinResult(b"out", b"err", 0)
+    host.BinResult(b"out", b"err", 0, forced_success=True)
+
+    if sys.version_info >= (3, 10):
+        with pytest.raises(TypeError):
+            host.Result("out", "err", 0, True)
+        with pytest.raises(TypeError):
+            host.BinResult(b"out", b"err", 0, True)
+    else:
+        host.Result("out", "err", 0, True)
+        host.BinResult(b"out", b"err", 0, True)
+
+
+def test_env() -> None:
+    res = host.local.run('echo ">>$FOO<<"', env={"FOO": "xx1"})
+    assert res == host.Result(">>xx1<<\n", "", 0)
+
+    res2 = run_local('echo ">>$FOO<<" 1>&2; exit 4', env={"FOO": "xx1"})
+    assert res2 == host.Result("", ">>xx1<<\n", 4)
+
+
+def test_cwd() -> None:
+    res = run_local("pwd", cwd="/usr/bin")
+    assert res == host.Result("/usr/bin\n", "", 0)
+
+    res = run_local(["pwd"], cwd="/usr/bin")
+    assert res == host.Result("/usr/bin\n", "", 0)
+
+    res = host.local.run("pwd", cwd="/usr/bin/does/not/exist")
+    assert res.out == ""
+    assert res.returncode == 1
+    assert "/usr/bin/does/not/exist" in res.err
+
+    res = host.local.run("pwd", cwd="/root")
+    if res == host.Result("/root\n", "", 0):
+        # We have permissions to access the directory.
+        pass
+    else:
+        assert res.out == ""
+        assert res.returncode == 1
+        assert "/root" in res.err
+
+
+def test_sudo() -> None:
+    skip_without_sudo(host.local)
+
+    rsh = host.LocalHost(sudo=True)
+
+    assert rsh.run("whoami") == host.Result("root\n", "", 0)
+
+    assert rsh.run(["whoami"]) == host.Result("root\n", "", 0)
+
+    res = rsh.run('echo ">>$FOO<"', env={"FOO": "xx1"})
+    assert res == host.Result(">>xx1<\n", "", 0)
+
+    res = rsh.run(
+        ["bash", "-c", 'echo ">>$FOO2<" >&2; exit 55'], env={"FOO2": "xx1", "F1": None}
+    )
+    assert res == host.Result("", ">>xx1<\n", 55)
+
+    res = rsh.run("pwd", cwd="/usr/bin")
+    assert res == host.Result("/usr/bin\n", "", 0)
+
+    res = rsh.run(["pwd"], cwd="/usr/bin")
+    assert res == host.Result("/usr/bin\n", "", 0)
+
+    res = rsh.run("echo hi; whoami >&2; pwd", cwd="/usr/bin")
+    assert res == host.Result("hi\n/usr/bin\n", "root\n", 0)
+
+    res = rsh.run(["bash", "-c", "echo hi; whoami >&2; pwd"], cwd="/usr/bin")
+    assert res == host.Result("hi\n/usr/bin\n", "root\n", 0)
+
+    res = rsh.run("pwd", cwd="/usr/bin/does/not/exist")
+    assert res.out == ""
+    assert res.returncode == 1
+    assert "/usr/bin/does/not/exist" in res.err
+
+    res = rsh.run("pwd", cwd="/root")
+    assert res == host.Result("/root\n", "", 0)
+
+
+def test_remotehost_userdoesnotexist() -> None:
+    skip_without_paramiko()
+
+    rsh = host.RemoteHost(
+        "localhost", host.AutoLogin(user="userdoesnotexist"), login_retry_duration=0
+    )
+    res = rsh.run("whoami")
+    assert res == host.Result(
+        out="",
+        err="Host.run(): failed to login to remote host localhost",
+        returncode=1,
+    )
+
+
+def test_remotehost_1() -> None:
+    user, rsh = skip_without_ssh_nopass()
+
+    res = rsh.run("whoami", **_rnd_log_lineoutput())
+    assert res == host.Result(f"{user}\n", "", 0)
+
+    res = rsh.run(
+        'whoami; pwd; echo ">>$FOO<"',
+        cwd="/usr",
+        env={"FOO": "hi"},
+        **_rnd_log_lineoutput(),
+    )
+    assert res == host.Result(f"{user}\n/usr\n>>hi<\n", "", 0)
+
+
+def test_remotehost_sudo() -> None:
+    user, rsh = skip_without_ssh_nopass()
+
+    res = rsh.run("whoami", sudo=True, **_rnd_log_lineoutput())
+    if res.success:
+        assert res == host.Result("root\n", "", 0)
+    else:
+        assert res.out == ""
+        assert "sudo" in res.err

--- a/ktoolbox/test_netdev.py
+++ b/ktoolbox/test_netdev.py
@@ -1,0 +1,130 @@
+import functools
+import pytest
+import socket
+
+from . import host
+from . import netdev
+
+
+@functools.cache
+def has_ip_route() -> bool:
+    return host.local.run("ip addr").returncode != 127
+
+
+def skip_without_ip_route() -> None:
+    if not has_ip_route():
+        pytest.skip("has no iproute2")
+
+
+def test_ip_addrs() -> None:
+    # We expect to have at least one address configured on the system and that
+    # `ip -json addr` works. The unit test requires that.
+    if not has_ip_route():
+        assert netdev.ip_addrs(host.local) == []
+    skip_without_ip_route()
+
+    assert netdev.ip_addrs(host.local)
+
+
+def test_ip_links() -> None:
+    if not has_ip_route():
+        assert netdev.ip_links(host.local) == []
+    skip_without_ip_route()
+
+    links = netdev.ip_links(host.local)
+    assert links
+    assert [link.ifindex for link in links if link.ifname == "lo"] == [1]
+
+    assert [link.ifindex for link in netdev.ip_links(host.local, ifname="lo")] == [1]
+
+    ifnames = netdev.get_ifnames()
+    for ifname in ifnames:
+        ipl = netdev.ip_links(ifname=ifname)
+        assert isinstance(ipl, list)
+        assert len(ipl) == 1
+        assert ipl[0].ifname == ifname
+
+
+def test_ip_routes() -> None:
+    # We expect to have at least one route configured on the system and that
+    # `ip -json route` works. The unit test requires that.
+    if not has_ip_route():
+        assert netdev.ip_routes(host.local) == []
+    skip_without_ip_route()
+
+    assert netdev.ip_routes(host.local)
+
+
+def test_sysctl_phys_port_name_parse() -> None:
+    assert netdev.sysctl_phys_port_name_parse("") is None
+    assert netdev.sysctl_phys_port_name_parse("  555\n") == (0, 555)
+    assert netdev.sysctl_phys_port_name_parse("  c1pf6vf55\n") == (6, 55)
+
+
+def test_validate_pciaddr() -> None:
+    assert netdev.validate_pciaddr(b"0000:ff:0a.7") == "0000:ff:0a.7"
+    assert netdev.validate_pciaddr("0000:ff:0a.7") == "0000:ff:0a.7"
+    with pytest.raises(Exception):
+        netdev.validate_pciaddr(b"0000:ff:0a.7/")
+    with pytest.raises(Exception):
+        netdev.validate_pciaddr("0000:ff:0A.7")
+
+
+def test_ifnames_and_pciaddrs() -> None:
+    ifnames = netdev.get_ifnames()
+    assert isinstance(ifnames, list)
+    assert all(isinstance(i, str) for i in ifnames)
+    assert "lo" in ifnames
+
+    pciaddrs = netdev.get_pciaddrs()
+    assert isinstance(pciaddrs, list)
+    assert all(isinstance(i, str) for i in pciaddrs)
+
+    ifname_to_pci: dict[str, str] = {}
+    pci_to_ifname: dict[str, str] = {}
+
+    for ifname1 in ifnames:
+        pciaddr = netdev.get_pciaddr_from_ifname(ifname1)
+        if pciaddr is not None:
+            assert pciaddr in pciaddrs
+            assert ifname1 in (netdev.get_ifnames_from_pciaddr(pciaddr) or ())
+            ifname_to_pci[ifname1] = pciaddr
+
+    for pci in pciaddrs:
+        ifnames2 = netdev.get_ifnames_from_pciaddr(pci)
+        if ifnames2 is not None:
+            for ifname2 in ifnames2:
+                assert ifname2 in ifnames
+                assert netdev.get_pciaddr_from_ifname(ifname2) == pci
+                pci_to_ifname[pci] = ifname2
+
+    assert {v: k for k, v in pci_to_ifname.items()} == ifname_to_pci
+    assert {v: k for k, v in ifname_to_pci.items()} == pci_to_ifname
+
+
+def test_get_device_infos() -> None:
+    result = netdev.get_device_infos()
+    assert isinstance(result, list)
+    assert "lo" in [x.get("ifname") for x in result]
+
+
+def test_validate_addr_family() -> None:
+    with pytest.raises(ValueError):
+        netdev.validate_addr_family(None)
+    assert netdev.validate_addr_family(None, with_unspec=True) == socket.AF_UNSPEC
+    with pytest.raises(ValueError):
+        netdev.validate_addr_family(socket.AF_UNSPEC)
+    assert (
+        netdev.validate_addr_family(socket.AF_UNSPEC, with_unspec=True)
+        == socket.AF_UNSPEC
+    )
+    assert netdev.validate_addr_family("4") == socket.AF_INET
+    assert netdev.validate_addr_family("6") == socket.AF_INET6
+    assert netdev.validate_addr_family(socket.AF_INET) == socket.AF_INET
+    assert netdev.validate_addr_family(socket.AF_INET6) == socket.AF_INET6
+
+
+def test_validate_ipaddr() -> None:
+    assert netdev.validate_ipaddr("::0:1") == ("::1", socket.AF_INET6)
+    assert netdev.validate_ipaddr("192.168.4.5") == ("192.168.4.5", socket.AF_INET)
+    assert netdev.validate_ipaddr(" 192.168.4.5") == ("192.168.4.5", socket.AF_INET)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,6 @@
 [mypy]
 
 [mypy-pexpect]
-ignore_missing_imports = True
+ignore_missing_imports = true
+[mypy-serial]
+ignore_missing_imports = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
+PyYAML>=6.0.1
+paramiko
 pexpect
+pyserial


### PR DESCRIPTION
The package "ktoolbox" from "ocp-traffic-flow-tests" is intended to be self-contained and usable at other places. Use it.

Reuse by copy+paste is often not great. It is however better than re-implementing and ending up with different variants of similar code. Also, reusing code makes it more attractive to provide solid implementations and invest effort in tests and quality that otherwise would not be warranted.

What makes re-use by copy+paste more palatable, is avoiding any local modifications to those files. Also, we don't cherry-pick parts of the module, but take all files without modification. The upstream location of those files is "ocp-traffic-flow-tests" (for now). Any changes should be done there first, and the whole module should be reimported. No local modifications or deviations should be done here. This avoids the problem where our fork deviates from the upstream source and improvements become difficult to merge, reconcile and share.

Getting this right, to not do any local modifications, requires self-restraint.

The imported version is [1].

[1] https://github.com/wizhaoredhat/ocp-traffic-flow-tests/tree/58298e4d247febe28d6269f20062ce2e32b4d4db/ktoolbox