### PR TITLE
[th/mypy-ini] mypy: set "files=." and "strict" in mypy.ini

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,6 @@
 [mypy]
+strict = true
+files = .
 
 [mypy-pexpect]
 ignore_missing_imports = true


### PR DESCRIPTION
Previously, the right way to run mypy was `mypy --strict .`. Set those options in "mypy.ini" file. You can still override it on the command line.