### PR TITLE
[th/pxeboot-features-1] add various features to pxeboot for setting up host+DPU (part 1)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,6 +5,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf install -y epel-next-release epel-release && \
     dnf upgrade -y --skip-broken --allowerasing && \
     dnf install \
+        /usr/bin/ssh-keygen \
         dhcp-server \
         ethtool \
         iproute \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Usage:
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest
 sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
-  ./pxeboot.py --dev eno4 /host/root/RHEL-9.4.0-20240312.96-aarch64-dvd1.iso
+  ./pxeboot.py --help
 ```
 
 ### FW Updater

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -3,6 +3,16 @@ import shlex
 import subprocess
 import dataclasses
 
+from typing import Optional
+
+from ktoolbox import host
+
+
+dpu_ip4addr = "172.131.100.100"
+dpu_ip4addrnet = f"{dpu_ip4addr}/24"
+host_ip4addr = "172.131.100.1"
+host_ip4addrnet = f"{host_ip4addr}/24"
+
 
 def minicom_cmd(device: str) -> str:
     return f"minicom -D {device}"
@@ -36,3 +46,35 @@ def run(cmd: str, env: dict[str, str] = os.environ.copy()) -> Result:
 
 def packaged_file(relative_path: str) -> str:
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), relative_path)
+
+
+def nmcli_setup_mngtiface(
+    ifname: str,
+    chroot_path: Optional[str],
+    ip4addr: str,
+) -> None:
+    """
+    Setup the management interface with a static IP address. For that, ensure we have
+    such a connection profile f"{ifname}-marvell-dpu" in NetworkManager. Configure static IP addresses.
+    """
+    chroot_prefix = ""
+    if chroot_path is not None:
+        chroot_prefix = f"chroot {shlex.quote(chroot_path)} "
+    con_name = f"{ifname}-marvell-dpu"
+    res = host.local.run(
+        f"{chroot_prefix}nmcli -g connection.uuid connection show id {shlex.quote(con_name)}"
+    )
+    if not res.success:
+        host.local.run(
+            f"{chroot_prefix}nmcli connection add type ethernet con-name {shlex.quote(con_name)} ifname {shlex.quote(ifname)} ipv4.method manual ipv4.addresses {shlex.quote(ip4addr)} ipv6.method link-local ipv6.addr-gen-mode eui64",
+            die_on_error=True,
+        )
+        con_spec = f"id {shlex.quote(con_name)}"
+    else:
+        uuid = res.out.split()[0]
+        con_spec = f"uuid {shlex.quote(uuid)}"
+        host.local.run(
+            f"{chroot_prefix}nmcli connection modify {con_spec} con-name {shlex.quote(con_name)} ifname {shlex.quote(ifname)} ipv4.method manual ipv4.addresses {shlex.quote(ip4addr)} ipv6.method link-local ipv6.addr-gen-mode eui64",
+            die_on_error=True,
+        )
+    host.local.run(f"{chroot_prefix}nmcli connection up {con_spec}", die_on_error=True)

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -78,3 +78,28 @@ def nmcli_setup_mngtiface(
             die_on_error=True,
         )
     host.local.run(f"{chroot_prefix}nmcli connection up {con_spec}", die_on_error=True)
+
+
+def ssh_generate_key(chroot_path: str) -> str:
+    file = f"{chroot_path}/root/.ssh/id_ed25519"
+    if not os.path.exists(file) or not os.path.exists(f"{file}.pub"):
+        try:
+            os.mkdir(os.path.dirname(file))
+        except FileExistsError:
+            pass
+        host.local.run(
+            f'ssh-keygen -t ed25519 -C marvell-tools@local.local -N "" -f {shlex.quote(file)}',
+            die_on_error=True,
+        )
+    return file
+
+
+def ssh_read_pubkey(ssh_privkey_file: str) -> str:
+    ssh_pubkey_file = f"{ssh_privkey_file}.pub"
+    with open(ssh_pubkey_file, "r") as f:
+        ssh_pubkey = f.read()
+    for s in ssh_pubkey.splitlines():
+        s = s.strip()
+        if s:
+            return s
+    raise RuntimeError('failure to read SSH public key from "{ssh_pubkey_file}"')

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -70,4 +70,47 @@ if [ -n "$SSH_PUBKEY" ] ; then
     printf '%s\n' "$SSH_PUBKEY" >> /root/.ssh/authorized_keys
 fi
 
+################################################################################
+
+cat <<EOF > /etc/NetworkManager/system-connections/enP2p2s0-dpu-secondary.nmconnection
+[connection]
+id=enP2p2s0-dpu-secondary
+uuid=$(uuidgen)
+type=ethernet
+autoconnect-priority=20
+interface-name=enP2p2s0
+
+[ipv4]
+method=auto
+dhcp-timeout=2147483647
+route-metric=110
+
+[ipv6]
+method=auto
+addr-gen-mode=eui64
+route-metric=110
+EOF
+chmod 600 /etc/NetworkManager/system-connections/enP2p2s0-dpu-secondary.nmconnection
+
+cat <<EOF > /etc/NetworkManager/system-connections/enP2p3s0-dpu-host.nmconnection
+[connection]
+id=enP2p3s0-dpu-host
+uuid=$(uuidgen)
+type=ethernet
+autoconnect-priority=10
+interface-name=enP2p3s0
+
+[ipv4]
+method=auto
+address1=@__DPU_IP4ADDRNET__@,@__HOST_IP4ADDR__@
+dhcp-timeout=2147483647
+route-metric=120
+
+[ipv6]
+method=auto
+addr-gen-mode=eui64
+route-metric=120
+EOF
+chmod 600 /etc/NetworkManager/system-connections/enP2p3s0-dpu-host.nmconnection
+
 %end

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -53,3 +53,21 @@ grubby
 xterm
 NetworkManager-config-server
 %end
+
+################################################################################
+#
+################################################################################
+
+%post --log=/var/log/kickstart_post.log
+
+set -x
+
+SSH_PUBKEY=@__SSH_PUBKEY__@
+if [ -n "$SSH_PUBKEY" ] ; then
+    mkdir -p /root/.ssh
+    touch /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+    printf '%s\n' "$SSH_PUBKEY" >> /root/.ssh/authorized_keys
+fi
+
+%end

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -113,4 +113,12 @@ route-metric=120
 EOF
 chmod 600 /etc/NetworkManager/system-connections/enP2p3s0-dpu-host.nmconnection
 
+################################################################################
+
+cat <<EOF >> /etc/chrony.conf
+
+# Appended by marvell-tools
+@__CHRONY_SERVERS__@
+EOF
+
 %end

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -182,6 +182,8 @@ def copy_kickstart(ssh_pubkey: list[str]) -> None:
     kickstart = kickstart.replace(
         "@__SSH_PUBKEY__@", shlex.quote("\n".join(ssh_pubkey))
     )
+    kickstart = kickstart.replace("@__DPU_IP4ADDRNET__@", common_dpu.dpu_ip4addrnet)
+    kickstart = kickstart.replace("@__HOST_IP4ADDR__@", common_dpu.host_ip4addr)
 
     with open("/www/kickstart.ks", "w") as f:
         f.write(kickstart)

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -49,6 +49,12 @@ def parse_args() -> argparse.Namespace:
         nargs="+",
         help='Specify SSH public keys to add to the DPU\'s /root/.ssh/authorized_keys. Can be specified multiple times. If unspecified or set to "", include "/{host-path}/root/.ssh/id_ed25519.pub" (this file will be generated if it doesn\'t exist).',
     )
+    parser.add_argument(
+        "--yum-repos",
+        choices=["none", "rhel-nightly"],
+        default="none",
+        help='We generate "/etc/yum.repos.d/marvell-tools-beaker.repo" with latest RHEL9 nightly compose. However, that repo is disabled unless "--yum-repos=rhel-nightly".',
+    )
 
     args = parser.parse_args()
     if not os.path.exists(args.iso):
@@ -177,15 +183,21 @@ def http_server() -> None:
     httpd.serve_forever()
 
 
-def copy_kickstart(host_path: str, ssh_pubkey: list[str]) -> None:
+def copy_kickstart(host_path: str, ssh_pubkey: list[str], yum_repos: str) -> None:
     with open(common_dpu.packaged_file("manifests/pxeboot/kickstart.ks"), "r") as f:
         kickstart = f.read()
+
+    yum_repo_enabled = yum_repos == "rhel-nightly"
 
     kickstart = kickstart.replace(
         "@__SSH_PUBKEY__@", shlex.quote("\n".join(ssh_pubkey))
     )
     kickstart = kickstart.replace("@__DPU_IP4ADDRNET__@", common_dpu.dpu_ip4addrnet)
     kickstart = kickstart.replace("@__HOST_IP4ADDR__@", common_dpu.host_ip4addr)
+    kickstart = kickstart.replace("@__YUM_REPO_URL__@", shlex.quote(""))
+    kickstart = kickstart.replace(
+        "@__YUM_REPO_ENABLED__@", shlex.quote("1" if yum_repo_enabled else "0")
+    )
 
     res = host.local.run(
         [
@@ -203,11 +215,11 @@ def copy_kickstart(host_path: str, ssh_pubkey: list[str]) -> None:
         f.write(kickstart)
 
 
-def setup_http(host_path: str, ssh_pubkey: list[str]) -> None:
+def setup_http(host_path: str, ssh_pubkey: list[str], yum_repos: str) -> None:
     os.makedirs("/www", exist_ok=True)
     run(f"ln -s {iso_mount_path} /www")
 
-    copy_kickstart(host_path, ssh_pubkey)
+    copy_kickstart(host_path, ssh_pubkey, yum_repos)
 
     p = Process(target=http_server)
     p.start()
@@ -284,7 +296,7 @@ def prepare_pxeboot(args: argparse.Namespace) -> None:
     setup_dhcp()
     mount_iso(args.iso)
     setup_tftp()
-    setup_http(args.host_path, ssh_pubkey)
+    setup_http(args.host_path, ssh_pubkey, args.yum_repos)
 
 
 def try_pxeboot(args: argparse.Namespace) -> None:


### PR DESCRIPTION
- pxeboot: configure nmcli connection profile on host for eno4
- pxeboot: generate and install SSH key on DPU
- pxeboot: create NetworkManager connection profiles on DPU during kickstart
- pxeboot: copy NTP servers to /etc/chrony.conf
- pxeboot: enable beaker nightly repository in kickstart
- pxeboot: support automatically downloading RHEL iso from URL


This is a spin-off from https://github.com/wizhaoredhat/marvell-octeon-10-tools/pull/7