### PR TITLE
[th/pxeboot-features-2] add various features to pxeboot for setting up host+DPU (part 2)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,6 +11,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         iproute \
         iputils \
         minicom \
+        nftables \
         procps \
         python-unversioned-command \
         python3-pexpect \

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -6,10 +6,12 @@ import subprocess
 
 from typing import Optional
 
+from ktoolbox import firewall
 from ktoolbox import host
 from ktoolbox.logger import logger
 
 
+dpu_subnet = "172.131.100.0/24"
 dpu_ip4addr = "172.131.100.100"
 dpu_ip4addrnet = f"{dpu_ip4addr}/24"
 host_ip4addr = "172.131.100.1"
@@ -80,6 +82,16 @@ def nmcli_setup_mngtiface(
             die_on_error=True,
         )
     host.local.run(f"{chroot_prefix}nmcli connection up {con_spec}", die_on_error=True)
+
+
+def nft_masquerade(ifname: str, subnet: str) -> None:
+    firewall.nft_call(
+        firewall.nft_data_masquerade_up(
+            table_name=f"marvell-tools-nat-{ifname}",
+            ifname=ifname,
+            subnet=subnet,
+        )
+    )
 
 
 def ssh_generate_key(chroot_path: str) -> str:

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -105,9 +105,11 @@ def nft_masquerade(ifname: str, subnet: str) -> None:
     )
 
 
-def ssh_generate_key(chroot_path: str) -> str:
+def ssh_generate_key(chroot_path: str, *, create: bool = True) -> Optional[str]:
     file = f"{chroot_path}/root/.ssh/id_ed25519"
     if not os.path.exists(file) or not os.path.exists(f"{file}.pub"):
+        if not create:
+            return None
         try:
             os.mkdir(os.path.dirname(file))
         except FileExistsError:

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -18,6 +18,10 @@ dpu_ip4addrnet = f"{dpu_ip4addr}/24"
 host_ip4addr = "172.131.100.1"
 host_ip4addrnet = f"{host_ip4addr}/24"
 
+ESC = "\x1b"
+KEY_DOWN = "\x1b[B"
+KEY_ENTER = "\r\n"
+
 
 def minicom_cmd(device: str) -> str:
     return f"minicom -D {device}"

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import subprocess
 
+from multiprocessing import Process
 from typing import Optional
 
 from ktoolbox import firewall
@@ -46,6 +47,12 @@ def run(cmd: str, env: dict[str, str] = os.environ.copy()) -> Result:
 
     print(f"Result: {result.out}\n{result.err}\n{result.returncode}\n")
     return result
+
+
+def run_process(cmd: str) -> Process:
+    p = Process(target=run, args=(cmd,))
+    p.start()
+    return p
 
 
 def packaged_file(relative_path: str) -> str:

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -4,7 +4,6 @@ import argparse
 import os
 import pexpect
 import shutil
-import signal
 import time
 
 from collections.abc import Iterable
@@ -182,26 +181,8 @@ def try_fwupdate(args: argparse.Namespace) -> None:
         e.terminate()
 
 
-def kill_existing() -> None:
-    pids = [pid for pid in os.listdir("/proc") if pid.isdigit()]
-
-    own_pid = os.getpid()
-    for pid in filter(lambda x: int(x) != own_pid, pids):
-        try:
-            with open(os.path.join("/proc", pid, "cmdline"), "rb") as f:
-                # print(f.read().decode("utf-8"))
-                zb = b"\x00"
-                cmd = [x.decode("utf-8") for x in f.read().strip(zb).split(zb)]
-                if "python" in cmd[0] and os.path.basename(cmd[1]) == "fwupdate.py":
-                    print(f"Killing pid {pid}")
-                    os.kill(int(pid), signal.SIGKILL)
-        except Exception:
-            pass
-
-
 def main() -> None:
     args = parse_args()
-    kill_existing()
     try_fwupdate(args)
 
 

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -11,6 +11,8 @@ from multiprocessing import Process
 
 import common_dpu
 
+from common_dpu import ESC
+from common_dpu import KEY_ENTER
 from common_dpu import minicom_cmd
 from common_dpu import run
 from reset import reset
@@ -64,11 +66,6 @@ def wait_any_ping(hn: Iterable[str], timeout: float) -> str:
 def ping(hn: str) -> bool:
     ping_cmd = f"timeout 1 ping -4 -c 1 {hn}"
     return run(ping_cmd).returncode == 0
-
-
-ESC = "\x1b"
-KEY_DOWN = "\x1b[B"
-KEY_ENTER = "\r\n"
 
 
 def firmware_update(img_path: str) -> None:

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -134,13 +134,6 @@ def firmware_update(img_path: str) -> None:
     print("Closing minicom")
 
 
-def uboot_firmware_update(args: argparse.Namespace) -> None:
-    print("Starting FW Update")
-    print("Resetting card")
-    reset()
-    firmware_update(args.img)
-
-
 def setup_tftp(img: str) -> None:
     print("Configuring TFTP")
     os.makedirs("/var/lib/tftpboot", exist_ok=True)
@@ -165,25 +158,20 @@ def setup_dhcp(dev: str) -> None:
     children.append(p)
 
 
-def prepare_fwupdate(args: argparse.Namespace) -> None:
+def main() -> None:
+    args = parse_args()
+    print("Preparing services for FW update")
     setup_dhcp(args.dev)
     setup_tftp(args.img)
-
-
-def try_fwupdate(args: argparse.Namespace) -> None:
-    print("Preparing services for FW update")
-    prepare_fwupdate(args)
     print("Giving services time to settle")
     time.sleep(10)
-    uboot_firmware_update(args)
+    print("Starting FW Update")
+    print("Resetting card")
+    reset()
+    firmware_update(args.img)
     print("Terminating http, tftp, and dhcpd")
     for e in children:
         e.terminate()
-
-
-def main() -> None:
-    args = parse_args()
-    try_fwupdate(args)
 
 
 if __name__ == "__main__":

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -167,4 +167,9 @@ chmod +x /etc/yum.repos.d/marvell-tools-beaker.sh
 
 /etc/yum.repos.d/marvell-tools-beaker.sh @__YUM_REPO_URL__@ @__YUM_REPO_ENABLED__@
 
+################################################################################
+
+# Allow password login as root.
+sed -i 's/.*PermitRootLogin.*/# \0\nPermitRootLogin yes/' /etc/ssh/sshd_config
+
 %end

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -22,7 +22,7 @@ skipx
 firstboot --disabled
 
 # Network information
-network --bootproto=dhcp --hostname=marvell-dpu.redhat --device=enP2p6s0 --activate
+network --bootproto=dhcp --hostname=@__FQDNNAME__@ --device=enP2p6s0 --activate
 
 ignoredisk --only-use=nvme0n1
 # System bootloader configuration

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -80,6 +80,9 @@ type=ethernet
 autoconnect-priority=20
 interface-name=enP2p2s0
 
+[ethernet]
+cloned-mac-address=@__NM_SECONDARY_CLONED_MAC_ADDRESS__@
+
 [ipv4]
 method=auto
 dhcp-timeout=2147483647

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -6,7 +6,6 @@ import os
 import pexpect
 import shlex
 import shutil
-import signal
 import time
 
 from collections.abc import Iterable
@@ -327,26 +326,8 @@ def try_pxeboot(args: argparse.Namespace) -> None:
     print("SUCCESS. Try `ssh root@dpu`")
 
 
-def kill_existing() -> None:
-    pids = [pid for pid in os.listdir("/proc") if pid.isdigit()]
-
-    own_pid = os.getpid()
-    for pid in filter(lambda x: int(x) != own_pid, pids):
-        try:
-            with open(os.path.join("/proc", pid, "cmdline"), "rb") as f:
-                # print(f.read().decode("utf-8"))
-                zb = b"\x00"
-                cmd = [x.decode("utf-8") for x in f.read().strip(zb).split(zb)]
-                if "python" in cmd[0] and os.path.basename(cmd[1]) == "pxeboot.py":
-                    print(f"Killing pid {pid}")
-                    os.kill(int(pid), signal.SIGKILL)
-        except Exception:
-            pass
-
-
 def main() -> None:
     args = parse_args()
-    kill_existing()
     try_pxeboot(args)
 
 

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -266,6 +266,9 @@ def prepare_host(dev: str, host_path: str, ssh_key: Optional[list[str]]) -> list
         ip4addr=common_dpu.host_ip4addrnet,
     )
 
+    common_dpu.nft_masquerade(ifname=dev, subnet=common_dpu.dpu_subnet)
+    host.local.run("sysctl -w net.ipv4.ip_forward=1")
+
     ssh_pubkey = []
 
     add_host_key = True

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -72,6 +72,12 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Installing the DPU also creates some ephemeral configuration. If you reboot the host, this is lost. Run the command with --host-setup-only to only recreate this configuration. This is idempotent.",
     )
+    parser.add_argument(
+        "--dpu-name",
+        type=str,
+        default="marvell-dpu",
+        help='The static hostname of the DPU. Defaults to "marvell-dpu". With "--host-mode=rhel" this is also added to /etc/hosts alongside "dpu".',
+    )
 
     return parser.parse_args()
 
@@ -186,26 +192,29 @@ def select_pxe_entry() -> None:
     print("Closing minicom")
 
 
-def write_hosts_entry(host_path: str) -> None:
+def write_hosts_entry(host_path: str, dpu_name: str) -> None:
     common.etc_hosts_update_file(
         {
-            "dpu": (common_dpu.dpu_ip4addr, None),
+            dpu_name: (common_dpu.dpu_ip4addr, ["dpu"]),
         },
         f"{host_path}/etc/hosts",
     )
 
 
-def post_pxeboot(host_mode: str, host_path: str) -> None:
+def post_pxeboot(host_mode: str, host_path: str, dpu_name: str) -> None:
     if host_mode == "rhel":
-        write_hosts_entry(host_path)
+        write_hosts_entry(host_path, dpu_name)
 
 
-def copy_kickstart(host_path: str, ssh_pubkey: list[str], yum_repos: str) -> None:
+def copy_kickstart(
+    host_path: str, dpu_name: str, ssh_pubkey: list[str], yum_repos: str
+) -> None:
     with open(common_dpu.packaged_file("manifests/pxeboot/kickstart.ks"), "r") as f:
         kickstart = f.read()
 
     yum_repo_enabled = yum_repos == "rhel-nightly"
 
+    kickstart = kickstart.replace("@__FQDNNAME__@", shlex.quote(f"{dpu_name}.redhat"))
     kickstart = kickstart.replace(
         "@__SSH_PUBKEY__@", shlex.quote("\n".join(ssh_pubkey))
     )
@@ -232,11 +241,13 @@ def copy_kickstart(host_path: str, ssh_pubkey: list[str], yum_repos: str) -> Non
         f.write(kickstart)
 
 
-def setup_http(host_path: str, ssh_pubkey: list[str], yum_repos: str) -> None:
+def setup_http(
+    host_path: str, dpu_name: str, ssh_pubkey: list[str], yum_repos: str
+) -> None:
     os.makedirs("/www", exist_ok=True)
     run(f"ln -s {iso_mount_path} /www")
 
-    copy_kickstart(host_path, ssh_pubkey, yum_repos)
+    copy_kickstart(host_path, dpu_name, ssh_pubkey, yum_repos)
 
     def http_server() -> None:
         os.chdir("/www")
@@ -342,7 +353,7 @@ def main() -> None:
         setup_dhcp()
         mount_iso(iso_path)
         setup_tftp()
-        setup_http(args.host_path, ssh_pubkey, args.yum_repos)
+        setup_http(args.host_path, args.dpu_name, ssh_pubkey, args.yum_repos)
         print("Giving services time to settle")
         time.sleep(10)
         print("Starting UEFI PXE Boot")
@@ -351,7 +362,7 @@ def main() -> None:
         select_pxe_entry()
         wait_for_boot()
 
-    post_pxeboot(host_mode, args.host_path)
+    post_pxeboot(host_mode, args.host_path, args.dpu_name)
 
     print("Terminating http, tftp, and dhcpd")
     for e in children:

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -53,7 +53,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--ssh-key",
         nargs="+",
-        help='Specify SSH public keys to add to the DPU\'s /root/.ssh/authorized_keys. Can be specified multiple times. If unspecified or set to "", include "/{host-path}/root/.ssh/id_ed25519.pub" (this file will be generated if it doesn\'t exist).',
+        help='Specify SSH public keys to add to the DPU\'s /root/.ssh/authorized_keys. Can be specified multiple times. If unspecified or set to "", include "/{host-path}/root/.ssh/id_ed25519.pub" (this file will be generated with "--host-mode=rhel" if it doesn\'t exist).',
     )
     parser.add_argument(
         "--yum-repos",
@@ -61,8 +61,35 @@ def parse_args() -> argparse.Namespace:
         default="none",
         help='We generate "/etc/yum.repos.d/marvell-tools-beaker.repo" with latest RHEL9 nightly compose. However, that repo is disabled unless "--yum-repos=rhel-nightly".',
     )
+    parser.add_argument(
+        "--host-mode",
+        choices=["auto", "rhel", "coreos"],
+        default="auto",
+        help='How to treat the host. With "rhel" we configure a (persisted) NetworkManager connection profile for device (eno4). With "coreos", this only configures an ad-hoc IP address with iproute. Port forwarding is always ephemeral via nft rules.',
+    )
+    parser.add_argument(
+        "--host-setup-only",
+        action="store_true",
+        help="Installing the DPU also creates some ephemeral configuration. If you reboot the host, this is lost. Run the command with --host-setup-only to only recreate this configuration. This is idempotent.",
+    )
 
     return parser.parse_args()
+
+
+def detect_host_mode(host_path: str, host_mode: str) -> str:
+    if host_mode == "auto":
+        if host.local.run(
+            [
+                "grep",
+                "-q",
+                'NAME="Red Hat Enterprise Linux"',
+                f"{host_path}/etc/os-release",
+            ]
+        ).success:
+            host_mode = "rhel"
+        else:
+            host_mode = "coreos"
+    return host_mode
 
 
 def ping(hn: str) -> bool:
@@ -168,8 +195,9 @@ def write_hosts_entry(host_path: str) -> None:
     )
 
 
-def post_pxeboot(host_path: str) -> None:
-    write_hosts_entry(host_path)
+def post_pxeboot(host_mode: str, host_path: str) -> None:
+    if host_mode == "rhel":
+        write_hosts_entry(host_path)
 
 
 def copy_kickstart(host_path: str, ssh_pubkey: list[str], yum_repos: str) -> None:
@@ -243,12 +271,22 @@ def setup_tftp() -> None:
     )
 
 
-def prepare_host(dev: str, host_path: str, ssh_key: Optional[list[str]]) -> list[str]:
-    common_dpu.nmcli_setup_mngtiface(
-        ifname=dev,
-        chroot_path=host_path,
-        ip4addr=common_dpu.host_ip4addrnet,
-    )
+def prepare_host(
+    host_mode: str,
+    dev: str,
+    host_path: str,
+    ssh_key: Optional[list[str]],
+) -> list[str]:
+    if host_mode == "rhel":
+        common_dpu.nmcli_setup_mngtiface(
+            ifname=dev,
+            chroot_path=host_path,
+            ip4addr=common_dpu.host_ip4addrnet,
+        )
+    else:
+        host.local.run(
+            f"ip addr add {shlex.quote(common_dpu.host_ip4addrnet)} dev {shlex.quote(dev)}"
+        )
 
     common_dpu.nft_masquerade(ifname=dev, subnet=common_dpu.dpu_subnet)
     host.local.run("sysctl -w net.ipv4.ip_forward=1")
@@ -265,7 +303,10 @@ def prepare_host(dev: str, host_path: str, ssh_key: Optional[list[str]]) -> list
                 ssh_pubkey.append(s)
 
     if add_host_key:
-        ssh_privkey_file = common_dpu.ssh_generate_key(host_path)
+        ssh_privkey_file = common_dpu.ssh_generate_key(
+            host_path,
+            create=(host_mode == "rhel"),
+        )
         if ssh_privkey_file is not None:
             ssh_pubkey.append(common_dpu.ssh_read_pubkey(ssh_privkey_file))
 
@@ -292,25 +333,36 @@ def mount_iso(iso_path: str) -> None:
 
 def main() -> None:
     args = parse_args()
+    host_mode = detect_host_mode(args.host_path, args.host_mode)
     print("Preparing services for Pxeboot")
-    ssh_pubkey = prepare_host(args.dev, args.host_path, args.ssh_key)
-    iso_path = common_dpu.create_iso_file(args.iso, chroot_path=args.host_path)
-    setup_dhcp()
-    mount_iso(iso_path)
-    setup_tftp()
-    setup_http(args.host_path, ssh_pubkey, args.yum_repos)
-    print("Giving services time to settle")
-    time.sleep(10)
-    print("Starting UEFI PXE Boot")
-    print("Resetting card")
-    reset()
-    select_pxe_entry()
-    wait_for_boot()
-    post_pxeboot(args.host_path)
+    ssh_pubkey = prepare_host(host_mode, args.dev, args.host_path, args.ssh_key)
+
+    if not args.host_setup_only:
+        iso_path = common_dpu.create_iso_file(args.iso, chroot_path=args.host_path)
+        setup_dhcp()
+        mount_iso(iso_path)
+        setup_tftp()
+        setup_http(args.host_path, ssh_pubkey, args.yum_repos)
+        print("Giving services time to settle")
+        time.sleep(10)
+        print("Starting UEFI PXE Boot")
+        print("Resetting card")
+        reset()
+        select_pxe_entry()
+        wait_for_boot()
+
+    post_pxeboot(host_mode, args.host_path)
+
     print("Terminating http, tftp, and dhcpd")
     for e in children:
         e.terminate()
-    print("SUCCESS. Try `ssh root@dpu`")
+
+    if args.host_setup_only:
+        print("SUCCESS (host-setup-only). Try `ssh root@dpu`")
+    elif host_mode == "rhel":
+        print("SUCCESS. Try `ssh root@dpu`")
+    else:
+        print(f"SUCCESS. Try `ssh root@{common_dpu.dpu_ip4addr}`")
 
 
 if __name__ == "__main__":

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -17,7 +17,11 @@ from ktoolbox import host
 
 import common_dpu
 
-from common_dpu import run, minicom_cmd
+from common_dpu import ESC
+from common_dpu import KEY_DOWN
+from common_dpu import KEY_ENTER
+from common_dpu import minicom_cmd
+from common_dpu import run
 from reset import reset
 
 
@@ -93,9 +97,6 @@ def wait_for_boot() -> None:
 
 def select_pxe_entry() -> None:
     print("selecting pxe entry")
-    ESC = "\x1b"
-    KEY_DOWN = "\x1b[B"
-    KEY_ENTER = "\r\n"
 
     run("pkill -9 minicom")
     print("spawn minicom")

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -13,6 +13,7 @@ from collections.abc import Iterable
 from multiprocessing import Process
 from typing import Optional
 
+from ktoolbox import common
 from ktoolbox import host
 
 import common_dpu
@@ -164,12 +165,26 @@ def select_pxe_entry() -> None:
     print("Closing minicom")
 
 
-def uefi_pxe_boot() -> None:
+def write_hosts_entry(host_path: str) -> None:
+    common.etc_hosts_update_file(
+        {
+            "dpu": (common_dpu.dpu_ip4addr, None),
+        },
+        f"{host_path}/etc/hosts",
+    )
+
+
+def post_pxeboot(host_path: str) -> None:
+    write_hosts_entry(host_path)
+
+
+def uefi_pxe_boot(args: argparse.Namespace) -> None:
     print("Starting UEFI PXE Boot")
     print("Resetting card")
     reset()
     select_pxe_entry()
     wait_for_boot()
+    post_pxeboot(args.host_path)
 
 
 def http_server() -> None:
@@ -302,10 +317,11 @@ def try_pxeboot(args: argparse.Namespace) -> None:
     prepare_pxeboot(args)
     print("Giving services time to settle")
     time.sleep(10)
-    uefi_pxe_boot()
+    uefi_pxe_boot(args)
     print("Terminating http, tftp, and dhcpd")
     for e in children:
         e.terminate()
+    print("SUCCESS. Try `ssh root@dpu`")
 
 
 def kill_existing() -> None:

--- a/reset.py
+++ b/reset.py
@@ -3,13 +3,9 @@
 import pexpect
 import time
 
+from common_dpu import KEY_ENTER
 from common_dpu import minicom_cmd
 from common_dpu import run
-
-
-ESC = "\x1b"
-KEY_DOWN = "\x1b[B"
-KEY_ENTER = "\r\n"
 
 
 def reset() -> None:


### PR DESCRIPTION
- pxeboot: add "dpu" entry to /etc/hosts
- pxeboot: setup masquerading rules via nft
- pxeboot,fwupdate: remove kill_existing() to kill other pxeboot.py processes
- pxeboot,fwupdate: move code around
- common_dpu: move key definitions to "common_dpu"
- pxeboot: add "--host-setup-only" and "--host-mode" options
- pxeboot: support "--dpu-name" to configure hostname of DPU
- pxeboot: allow password login via SSH for root user
- pxeboot: make "ethernet.cloned-mac-address" of "enP2p2s0-dpu-secondary" configurable

This is a spin-off from #7