### PR TITLE
[th/pxeboot-features-3] add various features to pxeboot for setting up host+DPU (part 3) 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,7 +14,6 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         nftables \
         procps \
         python-unversioned-command \
-        python3-pexpect \
         python3-pip \
         python3-pyserial \
         python3-pyyaml \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ sudo podman run --pull always --rm --replace --privileged --pid host --network h
 
 Utilize the serial interface at /dev/ttyUSB0 to pxeboot the card with the provided ISO
 
+The tool makes several assumptions.
+
+- The tool is for installing RHEL from an ISO via PXE. An HTTP url can be specified instead
+  of an URL, in that case, it is downloaded to "/host/root/rhel-iso-*". You can also set
+  "rhel:9.x" to use the latest RHEL 9.x nightly image.
+
+- The DPU's serial interface is on /dev/ttyUSB0.
+
+- The DPU's management interface (enP2p3s0) is connected back to the host (usually on "eno4", see "--dev" argument).
+  On the DPU, a NetworkManager profile "enP2p3s0-dpu-host" will be created with static IP address 172.131.100.100/24
+  (DHCP and SLAAC are enabled too).
+  On the host, "eno4" should have address 172.131.100.1/24 and setup NAT for forwarding traffic. The tool
+  takes care of that, see `nft list table ip marvell-tools-nat-eno4`.
+
+- The DPU's secondary interface (enP2p2s0) is connected to the provisioning host, where we expect to run DHCP.
+  On the DPU, a NetworkManager profile "enP2p3s0-dpu-secondary" will be created with DHCP and SLAAC enabled.
+  If a DHCP server is running on the other end, it should also setup NAT to connect the DPU to the internet.
+
+- Profile enP2p3s0-dpu-secondary has a better route metric than enP2p3s0-dpu-host and will be preferred to
+  reach the internet. Both profiles attempt DHCP/SLAAC indefinitely.
+
+- The host is expected to run RHEL or CoreOS. See also options "--host-setup-only" and "--host-mode".
+  On the host:
+
+  - It configures a NetworkManager connection profile "eno4-marvell-dpu" for "eno4" and activates it.
+    This configuration is persisted.
+
+  - Configures nftables (`nft list table ip marvell-tools-nat-eno4`) and "net.ipv4.ip_forward". This
+    configuration is ephemeral. It can be redone after reboot with "--host-setup-only".
+
+
 Usage:
 ```
 IMAGE=quay.io/sdaniele/marvell-tools:latest

--- a/common_dpu.py
+++ b/common_dpu.py
@@ -21,10 +21,10 @@ host_ip4addrnet = f"{host_ip4addr}/24"
 ESC = "\x1b"
 KEY_DOWN = "\x1b[B"
 KEY_ENTER = "\r\n"
+KEY_CTRL_M = "\r"
 
-
-def minicom_cmd(device: str) -> str:
-    return f"minicom -D {device}"
+TTYUSB0 = "/dev/ttyUSB0"
+TTYUSB1 = "/dev/ttyUSB1"
 
 
 @dataclasses.dataclass(frozen=True)

--- a/manifests/pxeboot/grub.cfg
+++ b/manifests/pxeboot/grub.cfg
@@ -1,6 +1,6 @@
 set timeout=10
 
 menuentry 'Install' {
-    linux pxelinux/vmlinuz ip=dhcp inst.repo=http://172.131.100.1/marvel_dpu_iso/ inst.ks=http://172.131.100.1/kickstart.ks
+    linux pxelinux/vmlinuz ip=dhcp inst.repo=http://172.131.100.1:24380/marvel_dpu_iso/ inst.ks=http://172.131.100.1:24380/kickstart.ks
     initrd pxelinux/initrd.img
 }

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -52,6 +52,7 @@ git
 grubby
 xterm
 NetworkManager-config-server
+podman
 %end
 
 ################################################################################

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -88,6 +88,7 @@ cloned-mac-address=@__NM_SECONDARY_CLONED_MAC_ADDRESS__@
 method=auto
 dhcp-timeout=2147483647
 route-metric=110
+@__NM_SECONDARY_IP_ADDRESS__@
 
 [ipv6]
 method=auto

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -22,7 +22,7 @@ skipx
 firstboot --disabled
 
 # Network information
-network --bootproto=dhcp --hostname=@__FQDNNAME__@ --device=enP2p6s0 --activate
+network --bootproto=dhcp --hostname=@__HOSTNAME__@ --device=enP2p6s0 --activate
 
 ignoredisk --only-use=nvme0n1
 # System bootloader configuration

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,7 +2,5 @@
 strict = true
 files = .
 
-[mypy-pexpect]
-ignore_missing_imports = true
 [mypy-serial]
 ignore_missing_imports = true

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -296,7 +296,7 @@ def setup_http(
 
     def http_server() -> None:
         os.chdir("/www")
-        server_address = ("", 80)
+        server_address = (common_dpu.host_ip4addr, 80)
         handler = http.server.SimpleHTTPRequestHandler
         httpd = http.server.HTTPServer(server_address, handler)
         httpd.serve_forever()

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -264,7 +264,7 @@ def copy_kickstart(
 
     yum_repo_enabled = yum_repos == "rhel-nightly"
 
-    kickstart = kickstart.replace("@__FQDNNAME__@", shlex.quote(f"{dpu_name}.redhat"))
+    kickstart = kickstart.replace("@__HOSTNAME__@", shlex.quote(dpu_name))
     kickstart = kickstart.replace(
         "@__SSH_PUBKEY__@", shlex.quote("\n".join(ssh_pubkey))
     )

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -83,6 +83,18 @@ def parse_args() -> argparse.Namespace:
         default="",
         help='The MAC address to configure on the "enP2p2s0-dpu-secondary" profile.',
     )
+    parser.add_argument(
+        "--nm-secondary-ip-address",
+        type=str,
+        default="",
+        help='If set, configure a static ipv4.addresses on the profile "enP2p2s0-dpu-secondary". This should contain the subnet, for example "192.168.122.5/24".',
+    )
+    parser.add_argument(
+        "--nm-secondary-ip-gateway",
+        type=str,
+        default="",
+        help='If set, configure ipv4.gateway on the "enP2p2s0-dpu-secondary" (requires "--nm-secondary-ip-address"). This should be in the same subnet as the address.',
+    )
 
     return parser.parse_args()
 
@@ -211,7 +223,15 @@ def copy_kickstart(
     ssh_pubkey: list[str],
     yum_repos: str,
     nm_secondary_cloned_mac_address: str,
+    nm_secondary_ip_address: str,
+    nm_secondary_ip_gateway: str,
 ) -> None:
+    ip_address = ""
+    if nm_secondary_ip_address:
+        ip_address = f"address1={nm_secondary_ip_address}"
+        if nm_secondary_ip_gateway:
+            ip_address += f",{nm_secondary_ip_gateway}"
+
     with open(common_dpu.packaged_file("manifests/pxeboot/kickstart.ks"), "r") as f:
         kickstart = f.read()
 
@@ -226,6 +246,10 @@ def copy_kickstart(
     kickstart = kickstart.replace(
         "@__NM_SECONDARY_CLONED_MAC_ADDRESS__@",
         nm_secondary_cloned_mac_address,
+    )
+    kickstart = kickstart.replace(
+        "@__NM_SECONDARY_IP_ADDRESS__@",
+        ip_address,
     )
     kickstart = kickstart.replace("@__YUM_REPO_URL__@", shlex.quote(""))
     kickstart = kickstart.replace(
@@ -254,12 +278,20 @@ def setup_http(
     ssh_pubkey: list[str],
     yum_repos: str,
     nm_secondary_cloned_mac_address: str,
+    nm_secondary_ip_address: str,
+    nm_secondary_ip_gateway: str,
 ) -> None:
     os.makedirs("/www", exist_ok=True)
     run(f"ln -s {iso_mount_path} /www")
 
     copy_kickstart(
-        host_path, dpu_name, ssh_pubkey, yum_repos, nm_secondary_cloned_mac_address
+        host_path,
+        dpu_name,
+        ssh_pubkey,
+        yum_repos,
+        nm_secondary_cloned_mac_address,
+        nm_secondary_ip_address,
+        nm_secondary_ip_gateway,
     )
 
     def http_server() -> None:
@@ -372,6 +404,8 @@ def main() -> None:
             ssh_pubkey,
             args.yum_repos,
             args.nm_secondary_cloned_mac_address,
+            args.nm_secondary_ip_address,
+            args.nm_secondary_ip_gateway,
         )
         print("Giving services time to settle")
         time.sleep(10)

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -296,7 +296,7 @@ def setup_http(
 
     def http_server() -> None:
         os.chdir("/www")
-        server_address = (common_dpu.host_ip4addr, 80)
+        server_address = (common_dpu.host_ip4addr, 24380)
         handler = http.server.SimpleHTTPRequestHandler
         httpd = http.server.HTTPServer(server_address, handler)
         httpd.serve_forever()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 PyYAML>=6.0.1
 paramiko
-pexpect
 pyserial

--- a/reset.py
+++ b/reset.py
@@ -1,38 +1,44 @@
 #!/usr/bin/env python3
 
-import pexpect
 import time
 
-from common_dpu import KEY_ENTER
-from common_dpu import minicom_cmd
-from common_dpu import run
+from ktoolbox.logger import logger
+from ktoolbox import common
+
+import common_dpu
+
+from common_dpu import KEY_CTRL_M
 
 
-def reset() -> None:
-    run("pkill -9 minicom")
-    print("spawn minicom")
-    child = pexpect.spawn(minicom_cmd("/dev/ttyUSB1"))
-    child.maxread = 10000
-    print("waiting for minicom startup menu")
-    child.expect("Welcome to minicom", timeout=3)
-    time.sleep(1)
-    print("pressing enter")
-    child.send(KEY_ENTER)
-    child.sendcontrol("m")
-    time.sleep(1)
-    print("Waiting on SCP Main Menu")
-    child.expect("SCP Main Menu", timeout=3)
-    child.sendline("m")
-    time.sleep(1)
-    child.sendcontrol("m")
-    time.sleep(1)
-    print("Waiting on SCP Management Menu")
-    child.expect("SCP Management Menu", timeout=3)
-    child.sendline("r")
-    time.sleep(1)
-    child.sendcontrol("m")
-    time.sleep(1)
-    child.close()
+def _reset(try_idx: int, retry_count: int) -> None:
+    logger.debug(f"serial: reset {common_dpu.TTYUSB1} (try {try_idx} of {retry_count})")
+    with common.Serial(common_dpu.TTYUSB1) as ser:
+        time.sleep(1)
+        ser.send(KEY_CTRL_M * 2)
+        ser.expect("SCP Main Menu")
+        ser.send("m" + KEY_CTRL_M)
+        ser.expect("SCP Management Menu")
+        ser.send("r" + KEY_CTRL_M, sleep=0.5)
+        buffer = ser.read_all()
+        logger.debug(
+            f"serial[{ser.port}]: reset complete (buffer content {repr(buffer)})"
+        )
+
+
+def reset(retry_count: int = 5) -> None:
+    try_idx = 0
+    while True:
+        try:
+            _reset(try_idx, retry_count)
+        except Exception as e:
+            logger.debug(f"serial: reset failed: {e}")
+            if try_idx + 1 == retry_count:
+                raise
+            try_idx += 1
+            logger.debug("serial: retry in 5 seconds")
+            time.sleep(5)
+            continue
+        return
 
 
 def main() -> None:


### PR DESCRIPTION
- kickstart: install podman on DPU
- README: explain more what pxeboot does
- all: use pyserial instead of minicom+pexpect
- pxeboot: support configuring static IP address and gateway on secondary interface
- pxeboot: bind HTTP server listening port to 172.131.100.1
- pxeboot: use http://172.131.100.1:24380/ for installation
- pxeboot: detect yum repo url during pxeboot
- pxeboot: only configure hostname in kickstart not the FQDN

This is a spin-off from #7