### PR TITLE
[th/run-and-ping-cleanup] cleanup run() commands

### DIFF
--- a/common_dpu.py
+++ b/common_dpu.py
@@ -64,6 +64,14 @@ def run_process(cmd: str) -> Process:
     return p
 
 
+def ping(hn: str) -> bool:
+    return host.local.run(
+        f"timeout 1 ping -4 -c 1 {shlex.quote(hn)}",
+        log_level=-1,
+        log_level_result=logging.DEBUG,
+    ).success
+
+
 def packaged_file(relative_path: str) -> str:
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), relative_path)
 

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -6,7 +6,6 @@ import shutil
 import time
 
 from collections.abc import Iterable
-from multiprocessing import Process
 
 from ktoolbox import common
 
@@ -16,6 +15,7 @@ from common_dpu import ESC
 from common_dpu import KEY_ENTER
 from common_dpu import logger
 from common_dpu import run
+from common_dpu import run_process
 from reset import reset
 
 
@@ -42,12 +42,6 @@ def parse_args() -> argparse.Namespace:
         raise Exception("Invalid path to omg provided")
 
     return args
-
-
-def run_process(cmd: str) -> Process:
-    p = Process(target=run, args=(cmd,))
-    p.start()
-    return p
 
 
 def wait_any_ping(hn: Iterable[str], timeout: float) -> str:

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -2,19 +2,20 @@
 
 import argparse
 import os
+import shlex
 import shutil
 import time
 
 from collections.abc import Iterable
 
 from ktoolbox import common
+from ktoolbox import host
 
 import common_dpu
 
 from common_dpu import ESC
 from common_dpu import KEY_ENTER
 from common_dpu import logger
-from common_dpu import run
 from common_dpu import run_process
 from reset import reset
 
@@ -120,7 +121,7 @@ def setup_tftp(img: str) -> None:
     print("Configuring TFTP")
     os.makedirs("/var/lib/tftpboot", exist_ok=True)
     print("starting in.tftpd")
-    run("killall in.tftpd")
+    host.local.run("killall in.tftpd")
     p = run_process("/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
     children.append(p)
     shutil.copy(f"{img}", "/var/lib/tftpboot")
@@ -128,12 +129,12 @@ def setup_tftp(img: str) -> None:
 
 def setup_dhcp(dev: str) -> None:
     print("Configuring DHCP")
-    run(f"ip addr add 172.131.100.1/24 dev {dev}")
+    host.local.run(f"ip addr add 172.131.100.1/24 dev {shlex.quote(dev)}")
     shutil.copy(
         common_dpu.packaged_file("manifests/pxeboot/dhcpd.conf"),
         "/etc/dhcp/dhcpd.conf",
     )
-    run("killall dhcpd")
+    host.local.run("killall dhcpd")
     p = run_process(
         "/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd"
     )

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -57,16 +57,11 @@ def wait_any_ping(hn: Iterable[str], timeout: float) -> str:
     hn = list(hn)
     while end - begin < timeout:
         for e in hn:
-            if ping(e):
+            if common_dpu.ping(e):
                 return e
         time.sleep(5)
         end = time.time()
     raise Exception(f"No response after {round(end - begin, 2)}s")
-
-
-def ping(hn: str) -> bool:
-    ping_cmd = f"timeout 1 ping -4 -c 1 {hn}"
-    return run(ping_cmd).returncode == 0
 
 
 def firmware_update(img_path: str) -> None:

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -19,7 +19,6 @@ from common_dpu import ESC
 from common_dpu import KEY_DOWN
 from common_dpu import KEY_ENTER
 from common_dpu import logger
-from common_dpu import run
 from reset import reset
 
 
@@ -296,7 +295,7 @@ def setup_http(
     nm_secondary_ip_gateway: str,
 ) -> None:
     os.makedirs("/www", exist_ok=True)
-    run(f"ln -s {iso_mount_path} /www")
+    host.local.run(f"ln -s {shlex.quote(iso_mount_path)} /www")
 
     copy_kickstart(
         host_path,
@@ -324,7 +323,7 @@ def setup_tftp() -> None:
     print("Configuring TFTP")
     os.makedirs("/var/lib/tftpboot/pxelinux", exist_ok=True)
     print("starting in.tftpd")
-    run("killall in.tftpd")
+    host.local.run("killall in.tftpd")
     p = common_dpu.run_process("/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
     children.append(p)
     shutil.copy(
@@ -388,7 +387,7 @@ def setup_dhcp() -> None:
     shutil.copy(
         common_dpu.packaged_file("manifests/pxeboot/dhcpd.conf"), "/etc/dhcp/dhcpd.conf"
     )
-    run("killall dhcpd")
+    host.local.run("killall dhcpd")
     p = common_dpu.run_process(
         "/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd"
     )
@@ -397,8 +396,10 @@ def setup_dhcp() -> None:
 
 def mount_iso(iso_path: str) -> None:
     os.makedirs(iso_mount_path, exist_ok=True)
-    run(f"umount {iso_mount_path}")
-    run(f"mount -t iso9660 -o loop {iso_path} {iso_mount_path}")
+    host.local.run(f"umount {shlex.quote(iso_mount_path)}")
+    host.local.run(
+        f"mount -t iso9660 -o loop {shlex.quote(iso_path)} {shlex.quote(iso_mount_path)}"
+    )
 
 
 def main() -> None:

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -114,11 +114,6 @@ def detect_host_mode(host_path: str, host_mode: str) -> str:
     return host_mode
 
 
-def ping(hn: str) -> bool:
-    ping_cmd = f"timeout 1 ping -4 -c 1 {hn}"
-    return run(ping_cmd).returncode == 0
-
-
 def wait_for_boot() -> None:
     print(f"Wait for boot and IP address {common_dpu.dpu_ip4addr}")
     end = time.monotonic() + 1800
@@ -126,7 +121,7 @@ def wait_for_boot() -> None:
     while True:
         time.sleep(sleep_time)
         sleep_time = max(int(sleep_time / 1.3), 9)
-        if ping(common_dpu.dpu_ip4addr):
+        if common_dpu.ping(common_dpu.dpu_ip4addr):
             print(f"got response from {common_dpu.dpu_ip4addr}")
             break
         if time.monotonic() > end:


### PR DESCRIPTION
- `wait_for_boot()` now waits for static IP 172.131.100.100 (which allows to drop the `sleep(1000)`).
- drop duplicated implementations of `ping()` and `run()`.
- replace `run()` with `ktoolbox.host.Host.local.run()`.
- minor cleanups.