### PR TITLE
[th/minicom-alias] pxeboot: install "Minicom" command on DPU

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -36,6 +36,7 @@ COPY ./*.py ./*sh ./mypy.ini /marvell-octeon-10-tools/
 COPY ./manifests /marvell-octeon-10-tools/manifests
 
 COPY manifests/.minirc.dfl /root/
+COPY manifests/Minicom /usr/bin/
 
 WORKDIR /marvell-octeon-10-tools
 ENTRYPOINT ["/usr/bin/tini", "-s", "-p", "SIGTERM", "-g", "-e", "143", "--"]

--- a/manifests/Minicom
+++ b/manifests/Minicom
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+[ $# -le 1 ] || { printf '%s\n' "$0: Too many arguments. Specify \"/dev/ttyUSB0\"" ; exit 1 ; }
+exec minicom -D "${1:-/dev/ttyUSB0}"


### PR DESCRIPTION
One major purpose of the marvell-tools container is to use it for manual debugging and access the terminal console.

For one, it has minicom installed (which CoreOS might not have). Also, it places a ".minirc.dfl" file to disable flow control. That makes it convenient to use.

Still, every time we have to type `minicom -D /dev/ttyUSB0`, and that command is also not in the bash history. For convenience, add a `Minicom` script that does this. It's really just to do less typing, now `M<TAB>` suffices.