### PR TITLE
[th/host-setup-only-flag] pxeboot: add shortcut flag "-H" for "--host-setup-only"

### DIFF
--- a/pxeboot.py
+++ b/pxeboot.py
@@ -65,6 +65,7 @@ def parse_args() -> argparse.Namespace:
         help='How to treat the host. With "rhel" we configure a (persisted) NetworkManager connection profile for device (eno4). With "coreos", this only configures an ad-hoc IP address with iproute. Port forwarding is always ephemeral via nft rules.',
     )
     parser.add_argument(
+        "-H",
         "--host-setup-only",
         action="store_true",
         help="Installing the DPU also creates some ephemeral configuration. If you reboot the host, this is lost. Run the command with --host-setup-only to only recreate this configuration. This is idempotent.",


### PR DESCRIPTION
The "--host-setup-only" is useful to run every time we reboot the host. It can be necessary to restore internet connectivity for the DPU by enabling NAT and configuring a static IP address.

However, the flag is hard to remember or type. Instead, add a "-H" shortcut which is easier to use.