### PR TITLE
[th/extra-packages-upstream-kernel] pxeboot: install upstream kernel RPM during kickstart

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -172,6 +172,11 @@ chmod +x /etc/yum.repos.d/marvell-tools-beaker.sh
 
 /etc/yum.repos.d/marvell-tools-beaker.sh @__YUM_REPO_URL__@ @__YUM_REPO_ENABLED__@
 
+EXTRA_PACKAGES=( @__EXTRA_PACKAGES__@ )
+if [ "${#EXTRA_PACKAGES[@]}" -gt 0 ] ; then
+    dnf install -y "${EXTRA_PACKAGES[@]}"
+fi
+
 ################################################################################
 
 # Allow password login as root.

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -175,6 +175,15 @@ chmod +x /etc/yum.repos.d/marvell-tools-beaker.sh
 EXTRA_PACKAGES=( @__EXTRA_PACKAGES__@ )
 if [ "@__DEFAULT_EXTRA_PACKAGES__@" = 1 ] ; then
     case "$(sed -n 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)" in
+        9.4)
+            # The rhel-9.4 kernel currently lacks patches for the Marvell DPU. Install
+            # a rebuild of upstream netnet kernel (with a rhel-9.4 config).
+            EXTRA_PACKAGES+=(
+                "http://file.brq.redhat.com/~thaller/marvell-octeon-10-tools/kernel-6.13.0_rc1.octeontx2_1_3d64c3d3c6d8+-1/kernel-6.13.0_rc1.octeontx2_1_3d64c3d3c6d8+-1.aarch64.rpm"
+                "http://file.brq.redhat.com/~thaller/marvell-octeon-10-tools/kernel-6.13.0_rc1.octeontx2_1_3d64c3d3c6d8+-1/kernel-devel-6.13.0_rc1.octeontx2_1_3d64c3d3c6d8+-1.aarch64.rpm"
+                "http://file.brq.redhat.com/~thaller/marvell-octeon-10-tools/kernel-6.13.0_rc1.octeontx2_1_3d64c3d3c6d8+-1/kernel-headers-6.13.0_rc1.octeontx2_1_3d64c3d3c6d8+-1.aarch64.rpm"
+            )
+            ;;
         *)
             ;;
     esac

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -173,6 +173,12 @@ chmod +x /etc/yum.repos.d/marvell-tools-beaker.sh
 /etc/yum.repos.d/marvell-tools-beaker.sh @__YUM_REPO_URL__@ @__YUM_REPO_ENABLED__@
 
 EXTRA_PACKAGES=( @__EXTRA_PACKAGES__@ )
+if [ "@__DEFAULT_EXTRA_PACKAGES__@" = 1 ] ; then
+    case "$(sed -n 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)" in
+        *)
+            ;;
+    esac
+fi
 if [ "${#EXTRA_PACKAGES[@]}" -gt 0 ] ; then
     dnf install -y "${EXTRA_PACKAGES[@]}"
 fi


### PR DESCRIPTION
At the moment, the RHEL-9.4 kernel lacks upstream patches to properly
handle the Marvell DPU. As a workaround for now, add means to install a
kernel RPM with latest upstream.

For now, only 9.4 packages exist. This workaround is temporary, so it's
probably fine.

The kernel is build in brew ([1]) via:

    # HOST: first, checkout 9.4 branch of
    # git@gitlab.com:redhat/rhel/src/kernel/rhel-9.git.
    # I used tag kernel-5.14.0-427.49.1.el9_4
    make -j12 dist-configs
    cp redhat/configs/kernel-5.14.0-aarch64.config /tmp/my-config

    # DPU: Second, on the DPU (or another aarch64 machine)
    # checkout latest main of
    # https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git
    git clone --depth=10 \
        https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git

    # HOST: From Host, copy config over
    scp -J root@wsfd-advnetlab41.anl.eng.bos2.dc.redhat.com \
        /tmp/my-config \
        root@192.168.123.7:net/.config

    # DPU: Create srpm. Press <ENTER> through all prompts
    echo ".octeontx2-1-$(git log -n1 --pretty='%h')" > localversion
    make -j$(nproc) srcrpm-pkg

    # HOST: Build in brew:
    scp -J root@wsfd-advnetlab41.anl.eng.bos2.dc.redhat.com \
      'root@192.168.123.7:/root/net/rpmbuild/SRPMS/kernel-*octeontx2*.src.rpm' .

    brew build --scratch rhel-9.4.0-test-pesign \
        --arch-override=aarch64 ./kernel-*octeontx2*.src.rpm

[1] https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=66180820
