### PR TITLE
[th/octep-cp-agent] build and add `octep_cp_agent` in arm64 container image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,42 @@
+FROM quay.io/centos/centos:stream9 AS builder-octep-cp-agent
+ARG TARGETPLATFORM
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
+        dnf upgrade -y && \
+        dnf install -y \
+            g++ \
+            gcc \
+            git-core ; \
+    fi
+
+WORKDIR /build/
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
+        curl -L -k -o /build/libconfig.tar.gz https://hyperrealm.github.io/libconfig/dist/libconfig-1.7.2.tar.gz && \
+        tar -C /build -xvf libconfig.tar.gz && \
+        git clone --depth=10 https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target.git ; \
+    fi
+
+WORKDIR /build/libconfig-1.7.2/
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
+        ./configure --host=aarch64-marvell-linux-gnu && \
+        make all ; \
+    fi
+
+WORKDIR /build/pcie_ep_octeon_target/target/libs/octep_cp_lib/
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
+        make CFLAGS="-DUSE_PEM_AND_DPI_PF=1" ; \
+    fi
+
+WORKDIR /build/pcie_ep_octeon_target/target/apps/octep_cp_agent/
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
+        make CFLAGS="-I/build/libconfig-1.7.2/lib -I/build/pcie_ep_octeon_target/target/libs/octep_cp_lib/bin/include" \
+             LDFLAGS="-L/build/libconfig-1.7.2/lib/.libs -L/build/pcie_ep_octeon_target/target/libs/octep_cp_lib/bin/lib" ; \
+    fi
+
+###############################################################################
+
 FROM quay.io/centos/centos:stream9
+ARG TARGETPLATFORM
 
 RUN dnf install -y 'dnf-command(config-manager)' && \
     dnf config-manager --set-enabled crb && \
@@ -37,6 +75,19 @@ COPY ./manifests /marvell-octeon-10-tools/manifests
 
 COPY manifests/.minirc.dfl /root/
 COPY manifests/Minicom /usr/bin/
+
+COPY --from=builder-octep-cp-agent /build/ /build/
+COPY manifests/run_octep_cp_agent /build/
+
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
+        mv /build/libconfig-1.7.2/lib/.libs/libconfig.so* /usr/lib/ && \
+        mv /build/pcie_ep_octeon_target/target/apps/octep_cp_agent/bin/bin/octep_cp_agent \
+           /build/pcie_ep_octeon_target/target/apps/octep_cp_agent/cn106xx.cfg \
+           /usr/bin/ && \
+        mv /build/run_octep_cp_agent /usr/bin/ && \
+        ldconfig ; \
+    fi && \
+    rm -rf /build/
 
 WORKDIR /marvell-octeon-10-tools
 ENTRYPOINT ["/usr/bin/tini", "-s", "-p", "SIGTERM", "-g", "-e", "143", "--"]

--- a/README.md
+++ b/README.md
@@ -82,3 +82,14 @@ killall in.tftpd
 systemctl stop tftp.service
 systemctl stop tftp.socket
 ```
+
+### Run octep_cp_agent
+
+On aarch64/arm64, the container also contains a build of octep_cp_agent from [github](https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target.git).
+See `/usr/bin/{octep_cp_agent,cn106xx.cfg}`. You can run:
+
+```
+IMAGE=quay.io/sdaniele/marvell-tools:latest
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools-cp-agent -v /:/host -v /dev:/dev -it "$IMAGE" \
+  run_octep_cp_agent
+```

--- a/manifests/run_octep_cp_agent
+++ b/manifests/run_octep_cp_agent
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -ex
+
+setup_hugepages() {
+    if ! mount | grep -q "^none on /dev/huge type hugetlbfs " ; then
+        mkdir -p /dev/huge
+        mount -t hugetlbfs none /dev/huge
+        echo 1024 > /proc/sys/vm/nr_hugepages
+    fi
+}
+
+run() {
+    # from http://file.brq.redhat.com/~thaller/SDP-CP-agent.docx
+    setup_hugepages
+    chroot /host modprobe vfio-pci
+    echo 0000:06:00.0 > /sys/bus/pci/drivers/mrvl_cn10k_dpi/unbind || :
+    echo vfio-pci > /sys/bus/pci/devices/0000:06:00.0/driver_override
+    echo vfio-pci > /sys/bus/pci/devices/0001:00:10.0/driver_override
+    echo 0000:06:00.0 > /sys/bus/pci/drivers_probe
+    echo 0001:00:10.0 > /sys/bus/pci/drivers_probe
+
+    exec /usr/bin/octep_cp_agent /usr/bin/cn106xx.cfg -- --dpi_dev 0000:06:00.0 --pem_dev 0001:00:10.0
+}
+
+run

--- a/scripts/build-container.sh
+++ b/scripts/build-container.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TAG="${TAG:-quay.io/$USER/marvell-tools:latest}"
+
+set -ex
+
+TAG="${1:-$TAG}"
+
+buildah manifest rm marvell-tools-manifest || true
+buildah manifest create marvell-tools-manifest
+buildah build --manifest marvell-tools-manifest --platform linux/amd64,linux/arm64 -t "$TAG" .
+buildah manifest push --all marvell-tools-manifest "docker://$TAG"


### PR DESCRIPTION
On the DPU, we will need to run the `octep_cp_agent` user space program from [here](https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target.git).

Build it in the arm64 container, so we can conveniently run it.