### PR TITLE
[th/no-nm-wait-online] pxeboot: disable "NetworkManager-wait-online.service" on the DPU

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -206,4 +206,6 @@ fi
 # Allow password login as root.
 sed -i 's/.*PermitRootLogin.*/# \0\nPermitRootLogin yes/' /etc/ssh/sshd_config
 
+systemctl disable NetworkManager-wait-online.service
+
 %end


### PR DESCRIPTION
NetworkManager-wait-online.service tends to hang, because the profiles are often known to linger in activating state. This service is not useful on the DPU. Disable it.