### PR TITLE
[th/update-default-packages] install `tcpdump` in container and remove `nano` from DPU

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -46,7 +46,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         /usr/bin/ssh-keygen \
         dhcp-server \
         ethtool \
-        git \
+        git-core \
         iproute \
         iputils \
         minicom \
@@ -59,9 +59,11 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         python3-requests \
         python3-types-pyyaml \
         python39 \
+        tcpdump \
         tftp \
         tftp-server \
         tini \
+        unzip \
         vim \
         -y && \
     echo "export PYTHONPATH=/marvell-octeon-10-tools" > /etc/profile.d/marvell-octeon-10-tools.sh

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -249,6 +249,10 @@ systemctl enable octep_cp_agent.service
 
 ################################################################################
 
+dnf remove -y nano
+
+################################################################################
+
 # Allow password login as root.
 sed -i 's/.*PermitRootLogin.*/# \0\nPermitRootLogin yes/' /etc/ssh/sshd_config
 


### PR DESCRIPTION
- pxeboot: uninstall "nano" via kickstart \
On the deployed RHEL on the DPU, uninstall `nano` package during kickstart. Having `nano` is so annoying, because it is the default editor and commands like `systemctl edit UNIT` will use it. Get rid of it.

- Containerfile: install "tcpdump" and "git-core" in marvell-tools container \
On the marvell-tools container, install `tcpdump` package. Also, install the smaller `git-core` package instead of `git`.
