### PR TITLE
[th/ssh-key-coreos] pxeboot: always create SSH keys also on CoreOS host

### DIFF
--- a/pxeboot.py
+++ b/pxeboot.py
@@ -406,7 +406,7 @@ def prepare_host(
     if add_host_key:
         ssh_privkey_file = common_dpu.ssh_generate_key(
             host_path,
-            create=(host_mode == "rhel"),
+            create=True,
         )
         if ssh_privkey_file is not None:
             ssh_pubkey.append(common_dpu.ssh_read_pubkey(ssh_privkey_file))


### PR DESCRIPTION
The pxeboot command has a "--host-mode" argument. For CoreOS, we do less modifications, because a CoreOS is immutable and certain things don't make sense.

However, the "/root" home directory is also persistet on CoreOS. It makes sense to generate a SSH key there, and install it on the DPU. The benefit is that you can SSH from the (CoreOS) host into the DPU, which is commonly at IP address 172.131.100.100.