### PR TITLE
[th/pxeboot-read-serial] pxeboot: wait and log serial console output

### DIFF
--- a/pxeboot.py
+++ b/pxeboot.py
@@ -204,6 +204,11 @@ def select_pxe_entry() -> None:
             # time.sleep(1)
             # timeout = 30
 
+        # Read and log the output for a bit longer. This way, we see how the
+        # DPU starts installation.
+        ser.expect(pattern=None, timeout=60)
+        logger.info(f"Closing serial console {ser.port}")
+
 
 def write_hosts_entry(host_path: str, dpu_name: str) -> None:
     common.etc_hosts_update_file(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
 paramiko
 pyserial
-git+https://github.com/thom311/ktoolbox@0e0db5c1fcecf896ab1e50b33900bb642ffe4ef8
+git+https://github.com/thom311/ktoolbox@6b914787314fff0b6d0b4d9e759cdea92967f4bc


### PR DESCRIPTION
After we select the right boot menu entry, the pxeboot command only
waits for the newly installed DPU to become ready.

In the background, the DPU will start PXE booting, and downloading
installation data via TFTP and HTTP. In the terminal, we see logging
After we select the right boot menu entry, the pxeboot command only
waits for the newly installed DPU to become ready.

In the background, the DPU will start PXE booting, and downloading
installation data via TFTP and HTTP. In the terminal, we see logging
messages from the HTTP server, but that may not be sufficient for
debugging.

Previously, we would no longer read the serial console at that point. So
if there is a problem and installation doesn't start, it's unclear why.

Avoid that, by keep reading the serial console for another minute and
log the output.

While it's a bit cumbersome, this way we can reconstruct from the
logfile every byte that was received.
