### PR TITLE
[th/iso-rhel-9.6] pxeboot: update default RHEL version for installation iso

### DIFF
--- a/common_dpu.py
+++ b/common_dpu.py
@@ -155,7 +155,7 @@ def create_iso_file(iso: str, chroot_path: str) -> str:
         rhel_version = iso0[len("rhel:") :]
         if rhel_version == "":
             # This is the default.
-            rhel_version = "9.4"
+            rhel_version = "9.6"
         url = f"https://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-{rhel_version}.0/compose/BaseOS/aarch64/iso/"
         res = host.local.run(
             f'curl -k -s {shlex.quote(url)} | sed -n \'s/.*href="\\(RHEL-[^"]\\+-dvd1.iso\\)".*/\\1/p\' | head -n1',


### PR DESCRIPTION
The default for pxeboot's ISO parameter is "rhel:".

That previously corresponded to "rhel:9.4".

Update that to "rhel:9.6".

It's unlikely that rhel-9.4 will support the DPU, because it requires a large number of kernel patches. We target rhel-9.6 now.