### PR TITLE
[th/pxeboot-fix-send-serial] fwupdate: fix serial console interaction when entering uboot menu

### DIFF
--- a/fwupdate.py
+++ b/fwupdate.py
@@ -14,7 +14,6 @@ from ktoolbox import host
 
 import common_dpu
 
-from common_dpu import ESC
 from common_dpu import KEY_ENTER
 from common_dpu import logger
 from common_dpu import run_process
@@ -123,8 +122,8 @@ def firmware_update(img_path: str, boot_device: str) -> None:
         ser.send("1")
         logger.info("waiting to escape to uboot menu")
         ser.expect("Hit any key to stop autoboot", 60)
-        logger.info("Sending escape 5 times")
-        ser.send(ESC * 5)
+        logger.info("Press ENTER for uboot menu")
+        ser.send(KEY_ENTER)
         logger.info("waiting on uboot prompt")
         ser.expect("crb106-pcie>", 5)
         logger.info("enabling 100G management port")


### PR DESCRIPTION
Pressing ESC a few times leaves the escape character in the uboot prompt and interferes with the next command. Instead, just press ENTER once, that is enough to enter the boot menu.
```
  2025-02-04 10:44:19.645 INFO    [th:139788358117184]: Sending escape 5 times
  2025-02-04 10:44:19.645 DEBUG   [th:139788358117184]: serial[/dev/ttyUSB0]: send '\x1b\x1b\x1b\x1b\x1b'
  2025-02-04 10:44:19.657 DEBUG   [th:139788358117184]: serial[/dev/ttyUSB0]: read buffer (5 + 25 unicode characters): '\x08\x08\x08 0 \r\ncrb106-pcie> \x1b\x1b\x1b\x1b'
  2025-02-04 10:44:20.646 INFO    [th:139788358117184]: waiting on uboot prompt
  2025-02-04 10:44:20.646 DEBUG   [th:139788358117184]: serial[/dev/ttyUSB0]: expect message 'crb106-pcie>'
  2025-02-04 10:44:20.646 DEBUG   [th:139788358117184]: serial[/dev/ttyUSB0]: found expected message 25 unicode characters, 5 remaning
  2025-02-04 10:44:20.646 INFO    [th:139788358117184]: enabling 100G management port
  2025-02-04 10:44:20.646 DEBUG   [th:139788358117184]: serial[/dev/ttyUSB0]: send 'setenv ethact rvu_pf#1'
  2025-02-04 10:44:20.649 DEBUG   [th:139788358117184]: serial[/dev/ttyUSB0]: read buffer (5 + 22 unicode characters): 'setenv ethact rvu_pf#1'
  2025-02-04 10:44:21.647 DEBUG   [th:139788358117184]: serial[/dev/ttyUSB0]: send '\r\n'
  2025-02-04 10:44:21.658 DEBUG   [th:139788358117184]: serial[/dev/ttyUSB0]: read buffer (27 + 100 unicode characters): "\r\nUnknown command '\x1b\x1b\x1b\x1bsetenv' - try 'help'\r\ncrb106-pcie> \r\nUnknown command '\x1b\x1b\x1b\x1bsetenv' - try 'help"
```