### PR TITLE
[th/run-process] common_dpu: don't use multiprocessing.Process but ktoolbox.common.FutureThread

### DIFF
--- a/common_dpu.py
+++ b/common_dpu.py
@@ -31,12 +31,26 @@ logger = common.ExtendedLogger("marvell_toolbox")
 common.log_config_logger(logging.DEBUG, logger, "ktoolbox")
 
 
-def run_process(cmd: Union[str, Iterable[str]]) -> common.FutureThread[host.Result]:
+def run_process(
+    tag: str,
+    cmd: Union[str, Iterable[str]],
+) -> common.FutureThread[host.Result]:
     return host.local.run_in_thread(
         cmd,
         log_lineoutput=True,
         add_to_thread_list=True,
+        user_data=tag,
     )
+
+
+def check_services_running() -> None:
+    for th in common.thread_list_get():
+        assert isinstance(th, common.FutureThread)
+        if th.poll() is None:
+            continue
+        logger.error(
+            f"Service {th.user_data} unexpectedly not running. Check logging output!!"
+        )
 
 
 def ping(hn: str) -> bool:

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -170,7 +170,7 @@ def setup_tftp(img: str) -> None:
     os.makedirs("/var/lib/tftpboot", exist_ok=True)
     logger.info("starting in.tftpd")
     host.local.run("killall in.tftpd")
-    run_process("/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
+    run_process("tftpd", "/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
     shutil.copy(f"{img}", "/var/lib/tftpboot")
 
 
@@ -182,7 +182,10 @@ def setup_dhcp(dev: str) -> None:
         "/etc/dhcp/dhcpd.conf",
     )
     host.local.run("killall dhcpd")
-    run_process("/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd")
+    run_process(
+        "dhcpd",
+        "/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd",
+    )
 
 
 def main() -> None:
@@ -192,7 +195,9 @@ def main() -> None:
     setup_dhcp(args.dev)
     setup_tftp(img)
     logger.info("Giving services time to settle")
-    time.sleep(10)
+    time.sleep(3)
+
+    common_dpu.check_services_running()
 
     if args.prompt:
         input(

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -27,8 +27,6 @@ DEFAULT_IMG_UEFI = (
     "http://file.brq.redhat.com/~thaller/marvell-sdk/flash-uefi-cn10ka-12.25.01.img"
 )
 
-children = []
-
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Process FW IMG file.")
@@ -172,8 +170,7 @@ def setup_tftp(img: str) -> None:
     os.makedirs("/var/lib/tftpboot", exist_ok=True)
     logger.info("starting in.tftpd")
     host.local.run("killall in.tftpd")
-    p = run_process("/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
-    children.append(p)
+    run_process("/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
     shutil.copy(f"{img}", "/var/lib/tftpboot")
 
 
@@ -185,10 +182,7 @@ def setup_dhcp(dev: str) -> None:
         "/etc/dhcp/dhcpd.conf",
     )
     host.local.run("killall dhcpd")
-    p = run_process(
-        "/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd"
-    )
-    children.append(p)
+    run_process("/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd")
 
 
 def main() -> None:
@@ -210,8 +204,7 @@ def main() -> None:
     reset()
     firmware_update(img, args.boot_device)
     logger.info("Terminating http, tftp, and dhcpd")
-    for e in children:
-        e.terminate()
+    common.thread_list_join_all()
 
 
 if __name__ == "__main__":

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -343,6 +343,7 @@ def setup_http(
     )
 
     common_dpu.run_process(
+        "httpd",
         [
             sys.executable,
             "-m",
@@ -350,7 +351,7 @@ def setup_http(
             "-d",
             "/www",
             "24380",
-        ]
+        ],
     )
 
 
@@ -359,7 +360,7 @@ def setup_tftp() -> None:
     os.makedirs("/var/lib/tftpboot/pxelinux", exist_ok=True)
     logger.info("starting in.tftpd")
     host.local.run("killall in.tftpd")
-    common_dpu.run_process("/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
+    common_dpu.run_process("tftp", "/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot")
     shutil.copy(
         f"{iso_mount_path}/images/pxeboot/vmlinuz", "/var/lib/tftpboot/pxelinux"
     )
@@ -423,7 +424,8 @@ def setup_dhcp() -> None:
     )
     host.local.run("killall dhcpd")
     common_dpu.run_process(
-        "/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd"
+        "dhcpd",
+        "/usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd",
     )
 
 
@@ -458,7 +460,10 @@ def main() -> None:
             args.default_extra_packages,
         )
         logger.info("Giving services time to settle")
-        time.sleep(10)
+        time.sleep(3)
+
+        common_dpu.check_services_running()
+
         if args.prompt:
             input(
                 "dhcp/tftp/http services started. Waiting. Press ENTER to continue or abort with CTRL+C"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
 paramiko
 pyserial
-git+https://github.com/thom311/ktoolbox@1a63c03fe2b8cf09abf0ade52361340b7b43c987
+git+https://github.com/thom311/ktoolbox@fcf77f24d96ffc613b675a07dfd8afbb5ef544cc


### PR DESCRIPTION
`multiprocessing.Process` has two modes. Either it spawns a new python interpreter, in which case it's unclear to me how it can redo all the necessary steps to reach the right internal state for handling the target callback. Or on Posix, what it does in our case, just fork() and then execute the target. The latter has the problem that it is only allowed to run async-signal-safe code between fork() and exec() (if you have multiple threads running, which is unknown).

Instead, use FutureThread and host.Host.run(). This results in nicer logging, and is supposed to do the right thing in any case. If it doesn't, we would want to find that bug in ktoolbox and fix our code, because we already use it at other places too. And if it does the right thing, then use it.

Also see the logging output previously:
```
2025-02-06 18:35:21.899 DEBUG   [th:139844862478144]: cmd[4;localhost]: call 'killall in.tftpd'
2025-02-06 18:35:21.899 INFO    [th:139844862478144]: running /usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd
2025-02-06 18:35:21.906 DEBUG   [th:139844862478144]: cmd[4;localhost]: └──> 'killall in.tftpd': failed (exit 1); err='in.tftpd: no process found\n'
```
Note that the "running /usr/sbin/dhcpd" line is actually printed by another process, but that is entirely unclear as the thread-id still shows the outdated value due to the fork() approach of multiprocessing.Process.

Also, we saw:
```
2025-02-06 18:48:24.490 INFO    [th:140039096514368]: running /usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot
2025-02-06 18:48:24.493 INFO    [th:140039096514368]: Result:

71

```
which does not clearly show what is going on. host.Host.run() does a better job here at printing what went wrong.
```
2025-02-06 18:49:58.855 DEBUG   [th:139811879827008]: cmd[6;localhost]: call '/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot'
...
2025-02-06 18:49:58.858 DEBUG   [th:139811879827008]: cmd[6;localhost]: └──> '/usr/sbin/in.tftpd -s -B 1468 -L /var/lib/tftpboot': failed (exit 71)
```
(also, note that the thread-id is only in the latter example correct).

Yes, this is likely more expensive, because we now have an additional thread to control the process. That is not important here.