### PR TITLE
[th/pxeboot-default-rhel] pxeboot: fix default for iso parameter to rhel:9.6

### DIFF
--- a/common_dpu.py
+++ b/common_dpu.py
@@ -145,6 +145,9 @@ def ssh_read_pubkey(ssh_privkey_file: str) -> str:
     raise RuntimeError('failure to read SSH public key from "{ssh_pubkey_file}"')
 
 
+DEFAULT_RHEL_ISO = "9.6"
+
+
 def create_iso_file(iso: str, chroot_path: str) -> str:
 
     iso0 = iso
@@ -155,7 +158,7 @@ def create_iso_file(iso: str, chroot_path: str) -> str:
         rhel_version = iso0[len("rhel:") :]
         if rhel_version == "":
             # This is the default.
-            rhel_version = "9.6"
+            rhel_version = DEFAULT_RHEL_ISO
         url = f"https://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-{rhel_version}.0/compose/BaseOS/aarch64/iso/"
         res = host.local.run(
             f'curl -k -s {shlex.quote(url)} | sed -n \'s/.*href="\\(RHEL-[^"]\\+-dvd1.iso\\)".*/\\1/p\' | head -n1',

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -32,8 +32,8 @@ def parse_args() -> argparse.Namespace:
         "iso",
         type=str,
         nargs="?",
-        default="rhel:9.4",
-        help='Select the RHEL ISO to install. This can be a file name (make sure to map the host with `-v /:/host` and specify the path name starting with "/host"); it can be a HTTP URL (in which case the file will be downloaded to /host/root/rhel-iso-$NAME if such file does not exist yet); it can also be "rhel:9.x" which will automatically detect the right HTTP URL to download the latest iso. Default: "rhel:" to choose a recent RHEL version',
+        default="rhel:",
+        help=f'Select the RHEL ISO to install. This can be a file name (make sure to map the host with `-v /:/host` and specify the path name starting with "/host"); it can be a HTTP URL (in which case the file will be downloaded to /host/root/rhel-iso-$NAME if such file does not exist yet); it can also be "rhel:9.x" which will automatically detect the right HTTP URL to download the latest iso. Default: "rhel:" to choose RHEL version {common_dpu.DEFAULT_RHEL_ISO}.',
     )
     parser.add_argument(
         "--dev",


### PR DESCRIPTION
Fixes: 0fb4404cbae3 ('pxeboot: update default RHEL version for installation iso')