### PR TITLE
[th/run-cp-agent-pull] pxeboot: use `podman run --pull newer` for running octep_cp_agent

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -215,7 +215,7 @@ NAME=marvell-tools-cp-agent
 
 case "$CMD" in
     run)
-        podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name "$NAME" -v /:/host -v /dev:/dev -it "$IMAGE" run_octep_cp_agent
+        podman run --pull newer --rm --replace --privileged --pid host --network host --user 0 --name "$NAME" -v /:/host -v /dev:/dev -it "$IMAGE" run_octep_cp_agent
         ;;
     stop)
         podman stop "$NAME"


### PR DESCRIPTION
pxeboot installs as octep_cp_agent.service systemd service, which runs /usr/bin/run_octep_cp_agent script. That script is generated by kickstart, and it runs a podman container via
```
podman run --pull always ...
```
This fails, if the DPU happens to have no internet access, which can easily happen if the gateway that we NAT through is not setup.

Instead, use "--pull newer" which tries to pull the image, but proceeds taking the old one, if it fails to do so.