### PR TITLE
[th/reset-boot-device] add option `./reset.py --boot-device [primary|secondary]` to select boot option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
 paramiko
 pyserial
-git+https://github.com/thom311/ktoolbox@fcf77f24d96ffc613b675a07dfd8afbb5ef544cc
+git+https://github.com/thom311/ktoolbox@510fa0668c9c10f8bd72c6ab6edaa8420303e005


### PR DESCRIPTION
as title says. Add option to `reset.py` so we can not only reboot the DPU, but also select which boot device to use.

This is relevant, because after a power off, the DPU always boots into the first boot device.