### PR TITLE
[th/export-kubeconfig] pxeboot: set KUBECONFIG environment variable

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -251,4 +251,6 @@ sed -i 's/.*PermitRootLogin.*/# \0\nPermitRootLogin yes/' /etc/ssh/sshd_config
 
 systemctl disable NetworkManager-wait-online.service
 
+echo 'export KUBECONFIG=/var/lib/microshift/resources/kubeadmin/kubeconfig' > /etc/profile.d/marvell-tools-kubeconfig.sh
+
 %end


### PR DESCRIPTION
We really expect to install microshift on the RHEL on the DPU. As such, the kubeconfig will be at a well known place. Set the KUBECONFIG environment variable to it. With this, if you have microshift running, `oc` command will just work.