### PR TITLE
[th/cp-agent-disable] add option to not enable octep_cp_agent.service

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -238,7 +238,9 @@ WantedBy=multi-user.target
 EOF
 
 systemctl daemon-reload
-systemctl enable octep_cp_agent.service
+if [ "@__OCTEP_CP_AGENT_SERVICE_ENABLE__@" = 1 ] ; then
+  systemctl enable octep_cp_agent.service
+fi
 
 ################################################################################
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
 paramiko
 pyserial
-git+https://github.com/thom311/ktoolbox@510fa0668c9c10f8bd72c6ab6edaa8420303e005
+git+https://github.com/thom311/ktoolbox@8620d5db39162615ee622d73be56e0575c3c88c8


### PR DESCRIPTION
For now, pxeboot.py creates and enables a `octep_cp_agent.service`, which runs the agent program.

Later, with https://github.com/openshift/dpu-operator/pull/303, the Marvell VSP of the dpu-operator will run the octep_cp_agent. In that case, we will no longer want to run the service (but probably it will always be useful to create it -- for some manual testing).

For now, add an option to disable it. It is still enabled by default. If 303 is merged, we will disable it by default.