### PR TITLE
[th/grub-hugepages] pxeboot: set hugepages via grub kernel cmdline

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -63,6 +63,13 @@ podman
 
 set -x
 
+################################################################################
+
+sed -i 's/^GRUB_CMDLINE_LINUX="\(.*\)"$/GRUB_CMDLINE_LINUX="\1 default_hugepagesz=32M hugepagesz=32M hugepages=8"/' /etc/default/grub
+grub2-mkconfig -o /boot/grub2/grub.cfg
+
+################################################################################
+
 SSH_PUBKEY=@__SSH_PUBKEY__@
 if [ -n "$SSH_PUBKEY" ] ; then
     mkdir -p /root/.ssh


### PR DESCRIPTION
We have kernel issue RHEL-78129 where binding the octeon_ep driver often fails to work with an error message about "Invalid magic number".

It appears that allocating hugetables on the kernel command line can avoid that issue.

In kickstart, patch "/etc/default/grub" to add a boot command line to do that.