### PR TITLE
[th/host-setup-ssh-trust] add "host-setup" script and install ssh-key

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -59,6 +59,7 @@ RUN dnf install -y 'dnf-command(config-manager)' && \
         python3-requests \
         python3-types-pyyaml \
         python39 \
+        sshpass \
         tcpdump \
         tftp \
         tftp-server \
@@ -77,6 +78,9 @@ COPY ./manifests /marvell-octeon-10-tools/manifests
 
 COPY manifests/.minirc.dfl /root/
 COPY manifests/Minicom /usr/bin/
+
+COPY manifests/ssh-trust-dpu /usr/bin/
+COPY manifests/host-setup /usr/bin/
 
 COPY --from=builder-octep-cp-agent /build/ /build/
 COPY manifests/exec_octep_cp_agent /build/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ The tool makes several assumptions.
   - Configures nftables (`nft list table ip marvell-tools-nat-eno4`) and "net.ipv4.ip_forward". This
     configuration is ephemeral. It can be redone after reboot with "--host-setup-only".
 
+  - see also [Host-setup](#Host-setup).
+
 
 Usage:
 ```
@@ -64,6 +66,20 @@ IMAGE=quay.io/sdaniele/marvell-tools:latest
 sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" \
   ./pxeboot.py --help
 ```
+
+### Host-setup
+
+From the host with the DPU, we call commands like `pxeboot.py` or `fwupdate.py`.
+
+We usually also want to setup that host in a way that is convenient for accessing the host.
+
+Run
+```
+IMAGE=quay.io/sdaniele/marvell-tools:latest
+sudo podman run --pull always --rm --replace --privileged --pid host --network host --user 0 --name marvell-tools -v /:/host -v /dev:/dev -it "$IMAGE" host-setup
+```
+
+This runs `pxeboot.py -H` and installs the ssh-key on the DPU (via `ssh-trust-dpu` script).
 
 ### FW Updater
 

--- a/manifests/host-setup
+++ b/manifests/host-setup
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -ex
+
+/marvell-octeon-10-tools/pxeboot.py -H
+ssh-trust-dpu

--- a/manifests/ssh-trust-dpu
+++ b/manifests/ssh-trust-dpu
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -ex
+
+IP=172.131.100.100
+HOSTNAME=dpu
+PASSWORD=redhat
+HOST_DIR="${HOST_DIR:-/host}"
+if [ -z "$SSH_DIR" ] ; then
+  SSH_DIR="$HOST_DIR/root/.ssh"
+fi
+
+mkdir -p "$SSH_DIR"/
+touch "$SSH_DIR"/known_hosts
+
+for host in "$IP" "$HOSTNAME" ; do
+  ssh-keygen -R "$host" -f "$SSH_DIR"/known_hosts || :
+  ssh-keyscan -H "$host" >> "$SSH_DIR"/known_hosts || :
+done
+
+for key in "$SSH_DIR"/*.pub ; do
+  sshpass -p "$PASSWORD" ssh-copy-id -o StrictHostKeyChecking=no -i "$key" "root@$IP" || :
+done


### PR DESCRIPTION
Usually, `pxeboot.py -H` ensures we have a ssh-key. Also, a full `pxeboot.py` installation will copy the ssh-key of the host as authorized_key to the DPU.

However, with dpu-operator's `make e2e-test`, we first (re)deploy the DPU before (re)deploying the worker node. So while the deployment of the DPU installs the SSH key at that time, afterwards the node gets reinstalled and gets a new SSH key. So when you ssh into the node, you cannot directly ssh into the DPU.

If you access the CoreOS worker node the first time, you probably anyway should run `pxeboot.py -H` to configure IP addresses on `eno4` interface and setup internet/masquerading.

Add `host-setup` script that runs `pxeboot.py -H` but also copies the new SSH key over to the DPU.

With this, you only run `host-setup` script and can access the DPU afterwards without further steps.