### PR TITLE
[th/enable-persistant-journal] pxeboot: enable persistent storage for systemd-journald syslogs

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -255,6 +255,10 @@ dnf remove -y nano
 
 ################################################################################
 
+mkdir -p /var/log/journal
+
+################################################################################
+
 # Allow password login as root.
 sed -i 's/.*PermitRootLogin.*/# \0\nPermitRootLogin yes/' /etc/ssh/sshd_config
 


### PR DESCRIPTION
For our development purposes, it seems useful to preserve logs.