### PR TITLE
[th/ssh-trust-dpu-fix] pxeboot: fix ssh-trust-dpu script for getting key for "dpu"

### DIFF
--- a/manifests/ssh-trust-dpu
+++ b/manifests/ssh-trust-dpu
@@ -17,9 +17,8 @@ for host in "$IP" "$HOSTNAME" ; do
   ssh-keygen -R "$host" -f "$SSH_DIR"/known_hosts || :
 done
 sleep 1
-for host in "$IP" "$HOSTNAME" ; do
-  ssh-keyscan -H "$host" >> "$SSH_DIR"/known_hosts || :
-done
+ssh-keyscan -H "$IP" >> "$SSH_DIR"/known_hosts || :
+chroot "$HOST_DIR" ssh-keyscan -H "$HOSTNAME" >> "$SSH_DIR"/known_hosts || :
 for key in "$SSH_DIR"/*.pub ; do
   sshpass -p "$PASSWORD" ssh-copy-id -o StrictHostKeyChecking=no -i "$key" "root@$IP" || :
 done


### PR DESCRIPTION
The "dpu" alias can be found in /host/etc/hosts file, not inside the container. For `ssh-keyscan dpu` to work, we must chroot.