### PR TITLE
[th/sdp-up-workarund] set interfaces up before starting cp-agent

### DIFF
--- a/manifests/exec_octep_cp_agent
+++ b/manifests/exec_octep_cp_agent
@@ -2,6 +2,15 @@
 
 set -ex
 
+ensure_sdp_up() {
+    # Seems that we must ensure that all SDP interfaces are always up (and up
+    # before anything else). See https://issues.redhat.com/browse/RHEL-90248
+    for f in $(cd /sys/class/net/ && ls -1d enP2p1s0* 2>/dev/null) ; do
+        ip link set "$f" up || :
+    done
+}
+
+
 setup_hugepages() {
     if [ "$(sed -n 's/^Hugepagesize: *//p' < /proc/meminfo)" != "32768 kB" ] ; then
         # octeon_cp_agent requires hugepages aligned to 4M. To achived that,
@@ -34,6 +43,9 @@ run() {
     # Follows [1].
     #
     # [1] https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target/blob/aa84a2331f76b68583e7b5861f17f5f3cef0fbd0/target/apps/octep_cp_agent/README#L107
+
+    ensure_sdp_up
+
     setup_hugepages
 
     chroot /host modprobe vfio-pci

--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -203,6 +203,33 @@ fi
 
 ################################################################################
 
+cat <<'EOF' > /usr/bin/dpu-monitor.sh
+#!/bin/bash
+
+ip -d link || :
+ip -ts monitor link addr route
+EOF
+
+chmod +x /usr/bin/dpu-monitor.sh
+
+cat <<'EOF' > /etc/systemd/system/dpu-monitor.service
+[Unit]
+Description=Monitor DPU for Debugging
+Before=octep_cp_agent.service
+Before=pre-network.target
+
+[Service]
+ExecStart=/usr/bin/dpu-monitor.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl daemon-reload
+systemctl enable dpu-monitor.service
+
+################################################################################
+
 cat <<'EOF' > /usr/bin/run_octep_cp_agent
 #!/bin/bash
 
@@ -243,6 +270,8 @@ Environment="IMAGE=quay.io/sdaniele/marvell-tools:latest"
 [Install]
 WantedBy=multi-user.target
 EOF
+
+################################################################################
 
 systemctl daemon-reload
 if [ "@__OCTEP_CP_AGENT_SERVICE_ENABLE__@" = 1 ] ; then


### PR DESCRIPTION
To workaround https://issues.redhat.com/browse/RHEL-90248 , we set all sdp interfaces up, before rebinding the driver and starting octep-cp-agent.

Also, during pxeboot (during kickstart) install a `/usr/bin/dpu-monitor.sh` script and a `dpu-montior.service` (which is enabled). This will run `ip montior`, so we can see in the log when the interface is set up (and down).