### PR TITLE
pxeboot: honor EXEC_OCTEP_CP_AGENT_SET_UP to avoid setting interfaces up

### DIFF
--- a/manifests/exec_octep_cp_agent
+++ b/manifests/exec_octep_cp_agent
@@ -44,7 +44,9 @@ run() {
     #
     # [1] https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target/blob/aa84a2331f76b68583e7b5861f17f5f3cef0fbd0/target/apps/octep_cp_agent/README#L107
 
-    ensure_sdp_up
+    if [ "$EXEC_OCTEP_CP_AGENT_SET_UP" != '0' ] ; then
+        ensure_sdp_up
+    fi
 
     setup_hugepages
 


### PR DESCRIPTION
For testing, I need to be able to not set the interface up. As the "octep_cp_agent.service" runs the script from inside the podman container, I cannot easily patch the script.

Honor EXEC_OCTEP_CP_AGENT_SET_UP="0" to skip setting the interface up. That way, I can edit the service file to tweak the behavior.