### PR TITLE
[th/cp-agent-update] octep_cp_agent: adjust octep_cp_agent for new firmware

### DIFF
--- a/manifests/exec_octep_cp_agent
+++ b/manifests/exec_octep_cp_agent
@@ -31,16 +31,13 @@ bind_vfio_pci() {
 }
 
 run() {
-    # Follows [1].
-    #
-    # [1] https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target/blob/aa84a2331f76b68583e7b5861f17f5f3cef0fbd0/target/apps/octep_cp_agent/README#L107
-
     setup_hugepages
 
     chroot /host modprobe vfio-pci
 
     pem="$(lspci -d 177d:a06c -n | awk 'NR==1{print $1}')"
     dpi="$(lspci -d 177d:a080 -n | awk 'NR==1{print $1}')"
+    read -ra rvu_pf_2 <<< "$(lspci -d 177d:a0ef -n | awk '{print $1}')"
 
     test -n "$pem"
     test -n "$dpi"
@@ -48,7 +45,18 @@ run() {
     bind_vfio_pci "$pem"
     bind_vfio_pci "$dpi"
 
-    exec /usr/bin/octep_cp_agent /usr/bin/cn106xx.cfg -- --dpi_dev "$dpi" --pem_dev "$pem"
+    if [ "${#rvu_pf_2[@]}" -ne 2 ] ; then
+        # https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target/blob/aa84a2331f76b68583e7b5861f17f5f3cef0fbd0/target/apps/octep_cp_agent/README#L107
+        cp_args=( --dpi_dev "$dpi" )
+        cp_agent="/usr/bin/octep_cp_agent.25.03.0"
+    else
+        # https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target/blob/35c9be07d2eefe1c909efefc9faa495db965a58e/target/apps/octep_cp_agent/README#L139
+        bind_vfio_pci "${rvu_pf_2[1]}"
+        cp_args=( --sdp_rvu_pf "${rvu_pf_2[1]}" )
+        cp_agent="/usr/bin/octep_cp_agent"
+    fi
+
+    exec "$cp_agent" /usr/bin/cn106xx.cfg -- "${cp_args[@]}" --pem_dev "$pem"
 }
 
 run


### PR DESCRIPTION
Currently our DPUs run UEFI firmware
```
  Firmware Version: 2025-01-30 22:07:22
  EBF Version: 12.25.01, Branch: /home/fae/PANW-LIO3/SDK122501/work/cn10ka-pcie-ep-release-output/build/marvell-external-fw-SDK12.25.01/firmware/ebf, Built: Thu, 30 Jan 2025 22:06:12 +0000
```
We want to upgrade to
```
  Firmware Version: 2025-07-30 15:48:38
  EBF Version: 12.25.06, Branch: /sdk/SDK12.25.06/cn10ka-vpp-release-output/build/marvell-external-fw-SDK12.25.06/firmware/ebf, Built: Wed, 30 Jul 2025 15:46:57 +0000
```
This requires a new octep_cp_agent version (and command line arguments). Then, firmware creates two RVU PFs to support split between BAR registers allowing two control plane applications to run. Latest octep_cp_agent uses second RVU PF instead of DPI.

Unfortunately, the new octep_cp_agent is not backward compatible with the previous firmware. This makes deployment cumbersome, because the version of octep_cp_agent must match the firmware. To avoid updating all DPUs in lockstep, go the extra mile and embed both octep_cp_agent versions in the container.

The used octep_cp_agent version is still 25.04.0 [1], because later versions seem not to work.

[1] https://github.com/MarvellEmbeddedProcessors/pcie_ep_octeon_target/commit/35c9be07d2eefe1c909efefc9faa495db965a58e