### PR TITLE
[th/run-main] better handle exeptions from main thread

### DIFF
--- a/common_dpu.py
+++ b/common_dpu.py
@@ -4,6 +4,7 @@ import shlex
 import shutil
 
 from collections.abc import Iterable
+from typing import Callable
 from typing import Optional
 from typing import Union
 
@@ -224,3 +225,10 @@ def create_iso_file(iso: str, chroot_path: str) -> str:
 
     logger.info(f"use iso {shlex.quote(iso2)}")
     return iso2
+
+
+def run_main(main_fcn: Callable[[], None]) -> None:
+    common.run_main(
+        main_fcn,
+        cleanup=common.thread_list_join_all,
+    )

--- a/fwupdate.py
+++ b/fwupdate.py
@@ -210,4 +210,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    common_dpu.run_main(main)

--- a/pxeboot.py
+++ b/pxeboot.py
@@ -519,4 +519,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    common_dpu.run_main(main)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
 paramiko
 pyserial
-git+https://github.com/thom311/ktoolbox@6601dd6cdf031f2f0daeb6ebe333cd6e0740e83a
+git+https://github.com/thom311/ktoolbox@c5fbd21faec841697673cf3c1797e481dfcfbc25

--- a/reset.py
+++ b/reset.py
@@ -103,4 +103,4 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    common_dpu.run_main(main)


### PR DESCRIPTION
When an exception is raised, we must kill the running threads via
`common.thread_list_join_all()`. Otherwise, the process is hanging while
the main thread exited.
    
Use `run_main()` helper for that. It also logs a useful error message.
