### PR TITLE
pxeboot: disable ip-link-up.service to re-reproduce RHEL-90248

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -262,7 +262,7 @@ WantedBy=multi-user.target
 EOF
 
 systemctl daemon-reload
-systemctl enable ip-link-up.service
+systemctl disable ip-link-up.service
 
 ################################################################################
 


### PR DESCRIPTION
We have kernel issue RHEL-90248. As a workaround, we added "ip-link-up.service", which keeps interfaces up. This workaround, enables us to pass the e2e-test tests and thus enable them in our CI.

Now we have a patch for that issue ([1]). But when testing it, so far I fail to reproduce the original problem. Which means, I don't know whether the problem is fixed (or what was the problem all along).

In an attempt to reproduce the problem, drop the workaround here.  If that again breaks CI, then that is desired and we have a basis for verifying the fix.

[1] https://issues.redhat.com/browse/RHEL-90248?focusedId=27841541&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27841541