### PR TITLE
[th/install-extra-test-kernel] pxeboot: install test kernel to verify RHEL-90248 patch

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -218,6 +218,14 @@ EXTRA_PACKAGES=( @__EXTRA_PACKAGES__@ )
 if [ "@__DEFAULT_EXTRA_PACKAGES__@" = 1 ] ; then
     case "$(sed -n 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)" in
         9.6)
+            # Install a kernel from RHEL-90248 to verify the patch.
+            EXTRA_PACKAGES+=(
+                "untrusted:http://file.corp.redhat.com/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
+                "untrusted:http://file.corp.redhat.com/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-core-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
+                "untrusted:http://file.corp.redhat.com/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-modules-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
+                "untrusted:http://file.corp.redhat.com/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-modules-core-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
+                "untrusted:http://file.corp.redhat.com/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-modules-extra-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
+            )
             ;;
         *)
             ;;


### PR DESCRIPTION

We have RHEL-90248 ([1]) issue ("Marvell DPU [octeon_ep] flakiness in sending
packets via VFs and via DPU").

A proposed solution was merged upstream as [2] [3] [4].

Install a test kernel during pxeboot to verify the fix.

See also commit 2fe30a0ce8bf ('pxeboot: disable ip-link-up.service to
re-reproduce RHEL-90248')

- [1] https://issues.redhat.com/browse/RHEL-90248
- [2] https://patchwork.kernel.org/project/netdevbpf/patch/20250820064625.1464361-1-hkelam@marvell.com/
- [3] https://lore.kernel.org/all/20250820064625.1464361-1-hkelam@marvell.com/
- [4] https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net-next.git/commit/?id=a7bd72158063740212344fad5d99dcef45bc70d6
