### PR TITLE
[th/revert-RHEL-90248-kernel]pxeboot: no longer install test kernel for reproducing RHEL-90248

### DIFF
--- a/manifests/pxeboot/kickstart.ks
+++ b/manifests/pxeboot/kickstart.ks
@@ -180,14 +180,8 @@ EXTRA_PACKAGES=( @__EXTRA_PACKAGES__@ )
 if [ "@__DEFAULT_EXTRA_PACKAGES__@" = 1 ] ; then
     case "$(sed -n 's/^VERSION_ID="\(.*\)"/\1/p' /etc/os-release)" in
         9.6)
-            # Install a kernel from RHEL-90248 to verify the patch.
             EXTRA_PACKAGES+=(
-                # From file.corp.redhat.com
-                "http://10.30.20.93/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
-                "http://10.30.20.93/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-core-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
-                "http://10.30.20.93/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-modules-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
-                "http://10.30.20.93/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-modules-core-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
-                "http://10.30.20.93/~thaller//marvell-octeon-10-tools/kernel-5.14.0-611.9.7_octeon.el9/aarch64/kernel-modules-extra-5.14.0-611.9.7_octeon.el9_7.aarch64.rpm"
+                # Nothing for now.
             )
             ;;
         *)


### PR DESCRIPTION
There was a lot of back and forth with RHEL-90248.

- first, there was a severe flakiness (RHEL-90248) which prevented us from enabling CI.
- then, a workaround was found by running a "ip-link-up.service" service in marvell-octeon-10-tools.
- then, an upstream kernel patch was identified which might fix RHEL-90248.
- at that point, I was unable to reproduce the original issue. Disabling the workaround "ip-link-up.service" seems to have mostly no effect. This is despite the kernel versions are similar (but not the same), the firmware and cp-agent versions were the same and the BIOS settings should be the same.
- as a result, RHEL-90248 was closed as CANT-REPRODUCE.
- still, marvell-octeon-10-tools was updated to install a test kernel via extra packages. That test kernel contains the upstream patch above.

Now, revert that test kernel again. Let's see how that goes.

If we don't notice any bad failures, the issues is really not reproducible. If we notice bad failures, then the patch is a fix for RHEL-90248. Given that there were already difficulties to reproduce RHEL-90248, I expect to be the former and the official kernel will work just as fine. Let's see.