### PR TITLE
[th/pxeboot-mac-addr] pxeboot: adjust regex for different MAC address for selecting boot entry

### DIFF
--- a/pxeboot.py
+++ b/pxeboot.py
@@ -782,7 +782,7 @@ def select_pxe_entry(ctx: RunContext, ser: common.Serial) -> None:
         try:
             # TODO: FIXME: We need to read the port configuration.
             # e.g. 80AA99887766 + number of lanes used in the SERDES
-            ser.expect("UEFI PXEv4.*MAC:80AA99887767", 0.5)
+            ser.expect("UEFI PXEv4.*MAC:(80AA99887767|000F......D4)", 0.5)
             break
         except Exception:
             retry -= 1


### PR DESCRIPTION
I followed Kiet's email with "howto_fix_mac_addresses.txt" to configure fixed MAC addresses. I ended up with:

    5) BOARD-MAC-ADDRESS-ID4 (0x000fb70655d4)

This means the UEFI boot menu looks now different.

Adjust the pattern to match either the old or the new MAC address. Note that the new pattern gives some room, so we could configure a slightly different MAC address on the various DPUs that we have.

This is not a great solution, but it unblocks it from now. In the future, we probably should improve the detection of the right boot entry.