### PR TITLE
[th/pxe-dpu-dev] pxeboot: add option to boot from primary/secondary DPU device

### DIFF
--- a/fwupdate.py
+++ b/fwupdate.py
@@ -166,7 +166,9 @@ def setup_tftp(img: str) -> None:
 
 def setup_dhcp(dev: str) -> None:
     host.local.run(f"ip addr add 172.131.100.1/24 dev {shlex.quote(dev)}")
-    common_dpu.run_dhcpd()
+    common_dpu.run_dhcpd(
+        dhcpd_conf=common_dpu.packaged_file("manifests/pxeboot/dhcpd.conf.fwupdate")
+    )
 
 
 def main() -> None:

--- a/manifests/pxeboot/dhcpd.conf.fwupdate
+++ b/manifests/pxeboot/dhcpd.conf.fwupdate
@@ -1,0 +1,25 @@
+option space pxelinux;
+option pxelinux.magic code 208 = string;
+option pxelinux.configfile code 209 = text;
+option pxelinux.pathprefix code 210 = text;
+option pxelinux.reboottime code 211 = unsigned integer 32;
+option architecture-type code 93 = unsigned integer 16;
+
+allow booting;
+allow bootp;
+
+next-server 172.131.100.1;
+always-broadcast on;
+
+subnet 172.131.100.0 netmask 255.255.255.0 {
+    range 172.131.100.10 172.131.100.20;
+    option broadcast-address 172.131.100.255;
+    option routers 172.131.100.1;
+    option domain-name-servers 10.11.5.160, 10.2.70.215;
+    option domain-search "anl.lab.eng.bos.redhat.com";
+    option dhcp-client-identifier = option dhcp-client-identifier;
+    class "pxeclients" {
+        match if substring(option vendor-class-identifier, 0, 9) = "PXEClient";
+        filename "/grubaa64.efi";
+    }
+}

--- a/manifests/pxeboot/dhcpd.conf.pxeboot
+++ b/manifests/pxeboot/dhcpd.conf.pxeboot
@@ -8,18 +8,25 @@ option architecture-type code 93 = unsigned integer 16;
 allow booting;
 allow bootp;
 
-next-server 172.131.100.1;
 always-broadcast on;
 
+host dpu-host {
+    hardware ethernet @__HARDWARE_ETHERNET__@;
+    fixed-address 172.131.100.100;
+    filename "@__PXE_FILENAME__@";
+    next-server 172.131.100.1;
+}
+
 subnet 172.131.100.0 netmask 255.255.255.0 {
-    range 172.131.100.10 172.131.100.20;
     option broadcast-address 172.131.100.255;
     option routers 172.131.100.1;
     option domain-name-servers 10.11.5.160, 10.2.70.215;
     option domain-search "anl.lab.eng.bos.redhat.com";
     option dhcp-client-identifier = option dhcp-client-identifier;
+
+    deny unknown-clients;
+
     class "pxeclients" {
         match if substring(option vendor-class-identifier, 0, 9) = "PXEClient";
-#__PXE_LINE__
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML
 paramiko
 pyserial
-git+https://github.com/thom311/ktoolbox@fcbb1d77023886bda8d0a3a6f3abc5d8b522aa43
+git+https://github.com/thom311/ktoolbox@9164f576a21d199ffd4830e3cd80001c9cebe09b


### PR DESCRIPTION
Add an option "--dpu-dev", which can be "primary", "secondary" or the
MAC address.

This determines which interface the pxeboot command will select to PXE
boot.

Also, the DHCP server now only replies to requests from the expected
hardware address. The purpose is that we can run the pxeboot DHCP server
on a network that already runs a regular DHCP server. And it would only
serve requests from the DPU.

This allows in the future to use the secondary interface for
installation. That interface is then free to use after installation. On
the other hand, the primary network is then available from the start to
connect to the OCP network. This requires a different switch setup than
what we had so far.
